### PR TITLE
Nice to have: Add web-ext config file 

### DIFF
--- a/web-ext-config.js
+++ b/web-ext-config.js
@@ -1,0 +1,15 @@
+const defaultConfig = {
+  sourceDir: "./src/",
+  artifactsDir: "./dist/",
+  ignoreFiles: [".DS_Store" ],
+  build: {
+    overwriteDest: true,
+  },
+  run: {
+    firefox: "nightly",
+    browserConsole: true,
+    startUrl: ["about:debugging"],
+  },
+};
+
+module.exports = defaultConfig;


### PR DESCRIPTION
Adding a web-ext config file so that when we `npm start` the extension automagically opens in Nightly, on `about:debugging`, with a browser console open.