### PR TITLE
Add Telemetry stuffholding so the CI is happy

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "addonslinter": "addons-linter --privileged src/",
     "typecheck": "tsc --noEmit",
     "build": "web-ext build --source-dir src --filename mozilla-vpn-extension.xpi",
-    "start": "web-ext run --verbose --source-dir src",
+    "start": "web-ext run --verbose --source-dir src --pref extensions.experiments.enabled=true",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "repository": {

--- a/src/background/telemetry.js
+++ b/src/background/telemetry.js
@@ -1,32 +1,34 @@
-import {Component} from "./component.js";
-import {constants} from "./constants.js";
-import {Logger} from "./logger.js";
+import { Component } from "./component.js";
+import { constants } from "./constants.js";
+import { Logger } from "./logger.js";
 
 const log = Logger.logger("Telemetry");
 
 const TELEMETRY_CATEGORY = "vpn.extension";
-// TODO: Add 
-const TELEMETRY_EVENTS = {
-
-};
-// TODO: Add 
-const TELEMETRY_SCALARS = {
-
-};
+// TODO: Add
+const TELEMETRY_EVENTS = {};
+// TODO: Add
+const TELEMETRY_SCALARS = {};
 
 export class Telemetry extends Component {
   constructor(receiver) {
     super(receiver);
-    browser.runtime.onInstalled.addListener(async details => this.onInstalled(details));
+    browser.runtime.onInstalled.addListener(async (details) =>
+      this.onInstalled(details)
+    );
     log("Registering telemetry events");
 
-    browser.telemetry.registerEvents(TELEMETRY_CATEGORY, TELEMETRY_EVENTS).catch(e => {
-      console.error("Failed to register telemetry events!", e);
-    });
+    browser.telemetry
+      .registerEvents(TELEMETRY_CATEGORY, TELEMETRY_EVENTS)
+      .catch((e) => {
+        console.error("Failed to register telemetry events!", e);
+      });
 
-    browser.telemetry.registerScalars(TELEMETRY_CATEGORY, TELEMETRY_SCALARS).catch(e => {
-      console.error("Failed to register telemetry scalars!", e);
-    });
+    browser.telemetry
+      .registerScalars(TELEMETRY_CATEGORY, TELEMETRY_SCALARS)
+      .catch((e) => {
+        console.error("Failed to register telemetry scalars!", e);
+      });
 
     this.version = "";
   }
@@ -61,19 +63,23 @@ export class Telemetry extends Component {
 
     const extraValues = {
       version: this.version,
-      ...extra
+      ...extra,
     };
 
-    browser.telemetry.recordEvent(TELEMETRY_CATEGORY, category, event, value, extraValues).catch(e => {
-      console.error("Telemetry.recordEvent failed", e);
-    });
+    browser.telemetry
+      .recordEvent(TELEMETRY_CATEGORY, category, event, value, extraValues)
+      .catch((e) => {
+        console.error("Telemetry.recordEvent failed", e);
+      });
   }
 
   syncAddScalar(scalarName, value) {
     log(`Sending telemetry scalar: ${scalarName} - ${value}`);
 
-    browser.telemetry.scalarAdd(TELEMETRY_CATEGORY + "." + scalarName, value).catch(e => {
-      console.error("Telemetry.scalarAdd failed", e);
-    });
+    browser.telemetry
+      .scalarAdd(TELEMETRY_CATEGORY + "." + scalarName, value)
+      .catch((e) => {
+        console.error("Telemetry.scalarAdd failed", e);
+      });
   }
 }

--- a/src/background/telemetry.js
+++ b/src/background/telemetry.js
@@ -1,5 +1,4 @@
 import { Component } from "./component.js";
-import { constants } from "./constants.js";
 import { Logger } from "./logger.js";
 
 const log = Logger.logger("Telemetry");

--- a/src/background/telemetry.js
+++ b/src/background/telemetry.js
@@ -1,0 +1,79 @@
+import {Component} from "./component.js";
+import {constants} from "./constants.js";
+import {Logger} from "./logger.js";
+
+const log = Logger.logger("Telemetry");
+
+const TELEMETRY_CATEGORY = "vpn.extension";
+// TODO: Add 
+const TELEMETRY_EVENTS = {
+
+};
+// TODO: Add 
+const TELEMETRY_SCALARS = {
+
+};
+
+export class Telemetry extends Component {
+  constructor(receiver) {
+    super(receiver);
+    browser.runtime.onInstalled.addListener(async details => this.onInstalled(details));
+    log("Registering telemetry events");
+
+    browser.telemetry.registerEvents(TELEMETRY_CATEGORY, TELEMETRY_EVENTS).catch(e => {
+      console.error("Failed to register telemetry events!", e);
+    });
+
+    browser.telemetry.registerScalars(TELEMETRY_CATEGORY, TELEMETRY_SCALARS).catch(e => {
+      console.error("Failed to register telemetry scalars!", e);
+    });
+
+    this.version = "";
+  }
+
+  async init() {
+    const self = await browser.management.getSelf();
+    this.version = self.version;
+  }
+
+  async onInstalled(details) {
+    if (details.reason === "install" || details.reason === "update") {
+      let version;
+
+      try {
+        let self = await browser.management.getSelf();
+        version = self.version;
+      } catch (e) {
+        version = null;
+      }
+
+      this.syncAddEvent("general", details.reason, version);
+    }
+  }
+
+  syncAddEvent(category, event, value = null, extra = null) {
+    log(`Sending telemetry: ${category} - ${event} - ${value} - ${extra}`);
+
+    if (constants.isAndroid) {
+      log(`No telemetry on android`);
+      return;
+    }
+
+    const extraValues = {
+      version: this.version,
+      ...extra
+    };
+
+    browser.telemetry.recordEvent(TELEMETRY_CATEGORY, category, event, value, extraValues).catch(e => {
+      console.error("Telemetry.recordEvent failed", e);
+    });
+  }
+
+  syncAddScalar(scalarName, value) {
+    log(`Sending telemetry scalar: ${scalarName} - ${value}`);
+
+    browser.telemetry.scalarAdd(TELEMETRY_CATEGORY + "." + scalarName, value).catch(e => {
+      console.error("Telemetry.scalarAdd failed", e);
+    });
+  }
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -44,5 +44,5 @@
     "default_title": "Page action button (TODO: Localize)"
   },
 
-  "permissions": ["<all_urls>", "nativeMessaging", "storage", "proxy", "tabs"]
+  "permissions": ["<all_urls>", "nativeMessaging", "storage", "proxy", "tabs","telemetry", "mozillaAddons"]
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -44,5 +44,13 @@
     "default_title": "Page action button (TODO: Localize)"
   },
 
-  "permissions": ["<all_urls>", "nativeMessaging", "storage", "proxy", "tabs","telemetry", "mozillaAddons"]
+  "permissions": [
+    "<all_urls>",
+    "nativeMessaging",
+    "storage",
+    "proxy",
+    "tabs",
+    "telemetry",
+    "mozillaAddons"
+  ]
 }


### PR DESCRIPTION
Currently the addons linter complains we're not using a priviledged permission... so let's do that? Given we probably want to use browser.telemetry. I'm pulling some boilerplate for later :) 