### PR TITLE
add observable properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 node_modules
 web-ext-artifacts
 dist/*
-
+coverage/
 # Mac OS X
 .DS_Store

--- a/src/background/requestHandler.js
+++ b/src/background/requestHandler.js
@@ -28,7 +28,7 @@ export class RequestHandler extends Component {
   async init() {
     log("Initiating RequestHandler");
 
-    this.controller.subscribe((s) => (this.controllerState = s));
+    this.controller.state.subscribe((s) => (this.controllerState = s));
 
     browser.proxy.onRequest.addListener(this.interceptRequests, {
       urls: ["<all_urls>"],

--- a/src/utils/property.js
+++ b/src/utils/property.js
@@ -1,0 +1,230 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @ts-check
+
+/**
+ * IBindable<T>:
+ *
+ * Represents a possibly changing value.
+ * - Changes can be subscribed to using `.subscribe( (newValue) => {})`
+ * - Current value can be read using `.value()`
+ * @template T
+ *
+ */
+class IBindable {
+  /**
+   * Returns the Current value
+   * @returns {T}
+   */
+  get value() {
+    throw new Error("not implemented");
+  }
+  /**
+   * Subscribe to changes of the Value
+   * @param {(T)=>void} _ - Callback when the value changes
+   * @returns {()=>void} - A Function to stop the subscription
+   */
+  subscribe(_) {
+    throw new Error("not implemented");
+  }
+}
+
+/**
+ * A property similar to Q_Property
+ * Holds an internal value that can be modified using `.set(NewValue)`
+ * Can be used to do Two Way Bindings
+ *
+ * A read only Bindable can be created using readOnly()
+ *
+ * @template T
+ */
+class Property extends IBindable {
+  /**
+   * Constructs a Property<T> with an initial Value
+   * @param {T} initialvalue
+   */
+  constructor(initialvalue) {
+    super();
+    this.#innerValue = initialvalue;
+  }
+  /** @returns {T}  */
+  get value() {
+    return this.#innerValue;
+  }
+  /** @param {T} v */
+  set value(v) {
+    this.set(v);
+  }
+  /**
+   * Sets the new value and notifies callbacks
+   * @param {T} value
+   */
+  set(value) {
+    this.#innerValue = value;
+    Object.freeze(value);
+    // Notify subscribtions
+    this.#subscriptions.forEach((s) => s(value));
+  }
+  /**
+   * Returns a bindable for the Property
+   * @returns {ReadOnlyProperty<T|null>}
+   */
+  get readOnly() {
+    return new ReadOnlyProperty(this);
+  }
+
+  /**
+   *
+   * @param {(T)=>void} callback - This callback will be called when the value changes
+   * @returns {()=>void} unsubscribe function, this will stop all callbacks
+   */
+  subscribe(callback) {
+    const unsubscribe = () => {
+      this.#subscriptions = this.#subscriptions.filter((t) => t !== callback);
+    };
+    this.#subscriptions.push(callback);
+    queueMicrotask(() => callback(this.#innerValue));
+    return unsubscribe;
+  }
+  /**
+   * @type {Array<(arg0: T)=>void> }
+   */
+  #subscriptions = [];
+  /**
+   * @type {T}
+   */
+  #innerValue;
+}
+
+/**
+ * A Read only View of a Property<T>
+ * Can be used to do One Way Bindings
+ *
+ * @template T
+ */
+class ReadOnlyProperty extends IBindable {
+  /**
+   * Constructs a Bindable<T> from a Property
+   * @param {IBindable<T>} binding
+   */
+  constructor(binding) {
+    super();
+    this.#property = binding;
+  }
+  get value() {
+    return this.#property.value;
+  }
+  /**
+   * Subscribe to changes of the Value
+   * @param {(T)=>void} callback - A callback
+   */
+  subscribe(callback) {
+    return this.#property.subscribe(callback);
+  }
+  /**
+   * @type {IBindable<T>}
+   */
+  #property;
+}
+
+/**
+ * @template T - Internal Type
+ * @template P - Parent Property Type
+ *
+ * A property consuming another property
+ * and applying a transform function
+ * before emitting the new value
+ *
+ */
+class LazyComputedProperty {
+  /**
+   * Constructs a Bindable<T> from a Property
+   * @param {Property<P>} parent - The proptery to read from
+   * @param {(arg0: (P|null) )=>T} transform - The function to apply
+   */
+  constructor(parent, transform) {
+    this.#parent = parent;
+    this.#transform = transform;
+    this.#innerValue = this.#transform(this.#parent.value);
+  }
+
+  get value() {
+    // If we're currently not subscribed, to the parent
+    // create the value on demand
+    if (!this.#parentUnsubscribe) {
+      return this.#transform(this.#parent.value);
+    }
+    // Otherwise innerValue is cached correctly
+    return this.#innerValue;
+  }
+  /**
+   * Subscribe to changes of the Value
+   * @param {(arg0: T)=>void} callback - A callback
+   */
+  subscribe(callback) {
+    if (!this.#parentUnsubscribe) {
+      this.#parentUnsubscribe = this.#parent.subscribe((parentValue) => {
+        this.#notify(this.#transform(parentValue));
+      });
+    }
+    const unsubscribe = () => {
+      this.unsubscribe(callback);
+    };
+    this.#subscriptions.push(callback);
+    return unsubscribe;
+  }
+  #notify(value) {
+    this.#innerValue = value;
+    this.#subscriptions.forEach((s) => s(value));
+  }
+  unsubscribe(callback) {
+    this.#subscriptions = this.#subscriptions.filter((t) => t !== callback);
+    // Noone listens to us, no need to hook into the parent
+    if (this.#subscriptions.length == 0 && this.#parentUnsubscribe) {
+      this.#parentUnsubscribe();
+      this.#parentUnsubscribe = null;
+    }
+  }
+
+  /**
+   * @type {Property<P>}
+   * The Parent Property
+   */
+  #parent;
+  /** @type { ?Function} */
+  #parentUnsubscribe = null;
+  /**
+   * @type {(arg0: P?)=>T}
+   */
+  #transform;
+  /**
+   * @type {Array<(arg0: T)=>void>}
+   */
+  #subscriptions = [];
+  /**
+   * @type {T?}
+   */
+  #innerValue = null;
+}
+
+/**
+ * @template T
+ * @param {T} value - Initial value of the Property
+ * @returns {Property<T>} - A Property
+ */
+export const property = (value) => {
+  return new Property(value);
+};
+
+/**
+ * @template T
+ * @template P
+ * @param {Property<P>} property - Callback when the value changes
+ * @param {(arg0: P?)=>T} transform - Called with the Property Value, must return the transformed value
+ * @returns {LazyComputedProperty<T,P>} - A Function to stop the subscription
+ */
+export const computed = (property, transform) => {
+  return new LazyComputedProperty(property, transform);
+};

--- a/tests/jest/utils/property.test.mjs
+++ b/tests/jest/utils/property.test.mjs
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, test } from "@jest/globals";
+import { property, computed } from "../../../src/utils/property";
+
+describe("property()", () => {
+  test("Can create a property from a value", () => {
+    const obj = { x: "hello" };
+    const prop = property(obj);
+    expect(prop.value.x).toBe(obj.x);
+  });
+  test("Listeners are notified of Changes", async () => {
+    const obj = { x: "hello" };
+    const prop = property(obj);
+
+    let maybeValue = null;
+    prop.subscribe((v) => (maybeValue = v));
+    prop.set({ value: "UPDATED" });
+    expect(maybeValue).not.toBeNull();
+    expect(maybeValue.value).toBe("UPDATED");
+  });
+  test("Listeners can unsubscribe ", () => {
+    const obj = { x: "hello" };
+    const prop = property(obj);
+    let maybeValue = null;
+    const unsub = prop.subscribe((v) => (maybeValue = v));
+    unsub();
+    prop.set({ value: "UPDATED" });
+    expect(maybeValue).toBeNull();
+  });
+});
+
+describe("ReadOnlyProperties", () => {
+  test("Can create a ReadOnlyProperty from a Property", () => {
+    const prop = property({ x: "hello" });
+    const ro = prop.readOnly;
+    expect(ro.value.x).toBe(prop.value.x);
+  });
+  test("Listeners are notified of Changes", async () => {
+    const prop = property({ x: "hello" });
+    const ro = prop.readOnly;
+
+    let maybeValue = null;
+    ro.subscribe((v) => (maybeValue = v));
+    prop.set({ value: "UPDATED" });
+    expect(maybeValue).not.toBeNull();
+    expect(maybeValue.value).toBe("UPDATED");
+  });
+  test("Listeners can unsubscribe ", () => {
+    const prop = property({ x: "hello" });
+    const ro = prop.readOnly;
+
+    let maybeValue = null;
+    const unsub = ro.subscribe((v) => (maybeValue = v));
+    unsub();
+    prop.set({ value: "UPDATED" });
+    expect(maybeValue).toBeNull();
+  });
+});
+
+describe("computed()", () => {
+  test("Can create a computed from a Property", () => {
+    const prop = property(1);
+    const computedProp = computed(prop, (num) => num * 2);
+    expect(computedProp.value).toBe(2);
+    prop.set(2);
+    expect(computedProp.value).toBe(4);
+  });
+  test("Listeners are notified of Changes", async () => {
+    const prop = property(1);
+    const computedProp = computed(prop, (num) => num * 2);
+    expect(computedProp.value).toBe(2);
+
+    let maybeValue = null;
+    computedProp.subscribe((v) => (maybeValue = v));
+    prop.set(2);
+    expect(maybeValue).not.toBeNull();
+    expect(maybeValue).toBe(4);
+  });
+});


### PR DESCRIPTION
This adds a small Property System capable of 1-Way, 2-Way bindings and lazy computed binding evaluation. 

Usage: 
```js
    const obj = { x: "hello" };
    const prop = property(obj);

    let maybeValue = null;
    prop.subscribe((v) => (maybeValue = v));
    prop.set({ value: "UPDATED" });
    expect(maybeValue).not.toBeNull();
```

I also change the VPNController to use that instead of it's own subscribtion logic