### PR TITLE
Main panel continues

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "addonslinter": "addons-linter --privileged src/",
     "typecheck": "tsc --noEmit",
     "build": "web-ext build --source-dir src --filename mozilla-vpn-extension.xpi",
-    "start": "web-ext run --verbose --source-dir src",
+    "start": "web-ext run --verbose --source-dir src --pref=ui.popup.disable_autohide=true ",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "repository": {

--- a/src/background/main.js
+++ b/src/background/main.js
@@ -84,4 +84,4 @@ main.init();
 globalThis["main"] = main;
 
 // Just do this for debugging
-//chrome.browserAction.openPopup();
+chrome.browserAction.openPopup();

--- a/src/background/vpncontroller/states.js
+++ b/src/background/vpncontroller/states.js
@@ -37,6 +37,11 @@ export class VPNState {
   /** @type {Array <ServerCountry> } */
   servers = [];
 
+  /** @type {ServerCity } */
+  exitServerCity = new ServerCity();
+
+  /** @type {ServerCountry } */
+  exitServerCountry = new ServerCountry();
   /**
    * Constructs state of another state, moving
    * non essential data.
@@ -122,14 +127,24 @@ export class StateVPNEnabled extends VPNState {
    *
    * @param {VPNState} other -
    * @param {string|boolean} aloophole - False if loophole is not supported,
+   * @param {ServerCity | undefined} exitServerCity - the Exit City
+   * @param {ServerCountry | undefined} exitServerCity - the Exit City
    */
-  constructor(other, aloophole) {
+  constructor(other, aloophole, exitServerCity, exitServerCountry) {
     super(other);
     if (other) {
       this.loophole = other.loophole;
+      this.exitServerCity = other.exitServerCity;
+      this.exitServerCountry = other.exitServerCountry;
     }
     if (aloophole) {
       this.loophole = aloophole;
+    }
+    if (exitServerCity) {
+      this.exitServerCity = exitServerCity;
+    }
+    if (exitServerCountry) {
+      this.exitServerCountry = exitServerCountry;
     }
   }
 

--- a/src/background/vpncontroller/states.js
+++ b/src/background/vpncontroller/states.js
@@ -130,7 +130,7 @@ export class StateVPNEnabled extends VPNState {
    * @param {ServerCity | undefined} exitServerCity - the Exit City
    * @param {ServerCountry | undefined} exitServerCity - the Exit City
    */
-  constructor(other, aloophole, exitServerCity, exitServerCountry) {
+  constructor(other, aloophole, exitServerCity, exitServerCountry) {   
     super(other);
     if (other) {
       this.loophole = other.loophole;

--- a/src/background/vpncontroller/vpncontroller.js
+++ b/src/background/vpncontroller/vpncontroller.js
@@ -174,10 +174,19 @@ export class VPNController extends Component {
       case "status":
         const status = response.status;
         const controllerState = status.vpn;
+
         if (controllerState === "StateOn") {
+          const exit_city_name = status.location["exit_city_name"];
+          const exit_country_code = status.location["exit_country_code"];
+
+          const exitServer = this.#mState.value.servers
+            .find((country) => country.code === exit_country_code)
+            ?.cities.find((city) => city.name === exit_city_name);
+
           this.#mState.value = new StateVPNEnabled(
             this.#mState.value,
-            status.localProxy?.url
+            status.localProxy?.url,
+            exitServer
           );
           return;
         }

--- a/src/background/vpncontroller/vpncontroller.js
+++ b/src/background/vpncontroller/vpncontroller.js
@@ -45,8 +45,8 @@ export class VPNController extends Component {
         this.handleResponse(response)
       );
 
-      this.postToApp("status");
       this.postToApp("servers");
+      this.postToApp("status");
 
       // When the mozillavpn dies or the VPN disconnects, we need to increase
       // the isolation key in order to create new proxy connections. Otherwise
@@ -136,6 +136,7 @@ export class VPNController extends Component {
       case "servers":
         // @ts-ignore
         const newState = new this.#mState.value.constructor({
+          ...this.#mState.value,
           servers: response.servers.countries,
         });
         VPNState.putIntoStorage(newState);
@@ -178,15 +179,16 @@ export class VPNController extends Component {
         if (controllerState === "StateOn") {
           const exit_city_name = status.location["exit_city_name"];
           const exit_country_code = status.location["exit_country_code"];
-
-          const exitServer = this.#mState.value.servers
+        
+          const exitServerCountry = this.#mState.value.servers
             .find((country) => country.code === exit_country_code)
-            ?.cities.find((city) => city.name === exit_city_name);
+          const exitServerCity = exitServerCountry?.cities.find((city) => city.name === exit_city_name);
 
           this.#mState.value = new StateVPNEnabled(
             this.#mState.value,
             status.localProxy?.url,
-            exitServer
+            exitServerCity,
+            exitServerCountry,
           );
           return;
         }

--- a/src/components/serverlist.js
+++ b/src/components/serverlist.js
@@ -5,6 +5,7 @@ import {
   classMap,
   styleMap,
 } from "../vendor/lit-all.min.js";
+import { resetSizing } from "./utils.js";
 
 import { ServerCity } from "../background/vpncontroller/states.js";
 
@@ -98,9 +99,7 @@ export class ServerList extends LitElement {
   }
 
   static styles = css`
-    #moz-vpn-server-list {
-      padding: 0;
-    }
+    ${resetSizing}
 
     #moz-vpn-server-list-panel {
       block-size: var(--panelSize);

--- a/src/components/utils.js
+++ b/src/components/utils.js
@@ -1,0 +1,84 @@
+import { css } from "../vendor/lit-all.min.js";
+
+/**
+ * Removes most Paddings & Margins
+ */
+export const resetSizing = css`
+  * {
+    margin: 0;
+    padding: 0;
+
+    box-sizing: border-box;
+  }
+  /* Remove default margin for body */
+  body {
+    margin: 0;
+  }
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    margin: 0;
+    padding: 0;
+  }
+  p {
+    margin: 0;
+    padding: 0;
+  }
+  ul,
+  ol {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+  blockquote {
+    margin: 0;
+    padding: 0;
+  }
+  table {
+    margin: 0;
+    padding: 0;
+    border-collapse: collapse;
+  }
+
+  th,
+  td {
+    margin: 0;
+    padding: 0;
+  }
+  form {
+    margin: 0;
+    padding: 0;
+  }
+
+  input,
+  button,
+  textarea,
+  select {
+    margin: 0;
+    padding: 0;
+  }
+  figure {
+    margin: 0;
+    padding: 0;
+  }
+  fieldset {
+    margin: 0;
+    padding: 0;
+  }
+
+  legend {
+    margin: 0;
+    padding: 0;
+  }
+  address {
+    margin: 0;
+    padding: 0;
+  }
+  pre {
+    margin: 0;
+    padding: 0;
+  }
+`;

--- a/src/components/utils.js
+++ b/src/components/utils.js
@@ -7,7 +7,6 @@ export const resetSizing = css`
   * {
     margin: 0;
     padding: 0;
-
     box-sizing: border-box;
   }
   /* Remove default margin for body */

--- a/src/components/vpncard.js
+++ b/src/components/vpncard.js
@@ -20,12 +20,17 @@ export class VPNCard extends LitElement {
   static properties = {
     enabled: { type: Boolean },
     connectedSince: { type: Date },
+    cityName: { type: String },
+    countryFlag: { type: String },
   };
 
   constructor() {
     super();
     this.enabled = false;
     this.connectedSince = Date.now();
+
+    this.cityName = "";
+    this.countryFlag = "";
   }
   #intervalHandle = null;
 
@@ -57,7 +62,6 @@ export class VPNCard extends LitElement {
 
     function formatSingle(value) {
       if (value === 0) return "00";
-
       return (value < 10 ? "0" : "") + value;
     }
     function formatTime(milliSeconds) {
@@ -84,14 +88,28 @@ export class VPNCard extends LitElement {
 
     return html`
       <div class="${classMap(boxClasses)}">
-        <img src=${shieldURL} />
-        <div class="infobox">
-          <h1>VPN is ${this.enabled ? "On" : "Off"}</h1>
-          <p>${subLine}</p>
-          ${timeString}
-        </div>
-        <button class="pill" @click=${this.#toggle}></button>
+        <main>
+          <img src=${shieldURL} />
+          <div class="infobox">
+            <h1>VPN is ${this.enabled ? "On" : "Off"}</h1>
+            <p>${subLine}</p>
+            ${timeString}
+          </div>
+          <button class="pill" @click=${this.#toggle}></button>
+          <hr />
+        </main>
+        ${this.enabled ? VPNCard.footer(this.cityName, this.countryFlag) : null}
       </div>
+    `;
+  }
+
+  static footer(name, countryFlag) {
+    return html`
+      <aside>
+        <img src="/../../assets/flags/${countryFlag}" />
+        <p>${name}</p>
+        <span> In Use </span>
+      </aside>
     `;
   }
 
@@ -108,11 +126,17 @@ export class VPNCard extends LitElement {
       border-radius: 8px;
       background: lch(from var(--panel-bg-color) calc(l + 5) c h);
       display: flex;
-      align-items: center;
+      align-items: flex-start;
       justify-content: space-between;
+      flex-direction: column;
     }
     .box.on {
       background: var(--main-card-background);
+    }
+    main {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
     }
 
     .box * {
@@ -176,8 +200,22 @@ export class VPNCard extends LitElement {
   static propertiesFrom(vpnState) {
     return {
       enabled: vpnState.connected,
+      name: vpnState.exitServerCity?.name,
+      flag: vpnState.exitServerCountry?.code,
       connectedSince: Date.now(), // TODO: We actually dont send this from the client
     };
+  }
+  /**
+   * Returns the Properties this element should have based on a VPN State
+   * @param {VPNState} vpnState
+   * @returns {void}
+   */
+  apply(vpnState) {
+    const bag = VPNCard.propertiesFrom(vpnState);
+    this.enabled = bag.enabled;
+    this.cityName = bag.cityName;
+    this.countryFlag = bag.flag;
+    this.connectedSince = bag.connectedSince;
   }
 }
 customElements.define("vpn-card", VPNCard);

--- a/src/components/vpncard.js
+++ b/src/components/vpncard.js
@@ -10,6 +10,8 @@ import {
   styleMap,
 } from "../vendor/lit-all.min.js";
 
+import { resetSizing } from "./utils.js";
+
 /**
  * @typedef {import("../background/vpncontroller/states.js").VPNState} VPNState
  */
@@ -94,6 +96,8 @@ export class VPNCard extends LitElement {
   }
 
   static styles = css`
+    ${resetSizing}
+
     :host {
       font-size: 1rem;
       font-family: var(--font-family);
@@ -129,8 +133,6 @@ export class VPNCard extends LitElement {
       font-weight: 700;
     }
     p {
-      padding: 0;
-      margin: 0;
       font-size: 14px;
       line-height: 21px;
       font-weight: 400;

--- a/src/components/vpncard.js
+++ b/src/components/vpncard.js
@@ -96,7 +96,6 @@ export class VPNCard extends LitElement {
             ${timeString}
           </div>
           <button class="pill" @click=${this.#toggle}></button>
-          <hr />
         </main>
         ${this.enabled ? VPNCard.footer(this.cityName, this.countryFlag) : null}
       </div>
@@ -105,11 +104,11 @@ export class VPNCard extends LitElement {
 
   static footer(name, countryFlag) {
     return html`
-      <aside>
-        <img src="/../../assets/flags/${countryFlag}" />
+      <footer>
+        <img src="../../assets/flags/${countryFlag}.png" width="24" height="24" />
         <p>${name}</p>
         <span> In Use </span>
-      </aside>
+      </footer>
     `;
   }
 
@@ -122,7 +121,6 @@ export class VPNCard extends LitElement {
       --default-padding: 16px;
     }
     .box {
-      padding: var(--default-padding);
       border-radius: 8px;
       background: lch(from var(--panel-bg-color) calc(l + 5) c h);
       display: flex;
@@ -133,10 +131,29 @@ export class VPNCard extends LitElement {
     .box.on {
       background: var(--main-card-background);
     }
-    main {
+    main, footer {
       display: flex;
       align-items: center;
+      width: 100%;
+      justify-content: baseline;
+    }
+    main{
       justify-content: space-between;
+      padding: var(--default-padding);
+    }
+    footer{
+      justify-content: flex-start;
+      width: 100%;
+      border-top: 1px solid var(--border-color);
+      padding: 10px var(--default-padding);
+    }
+    footer p{
+      color: var(--text-color-primary);
+      font-size: 14px;
+    }
+    footer span{
+      font-size: 11px;
+      font-weight: bold;
     }
 
     .box * {
@@ -190,6 +207,16 @@ export class VPNCard extends LitElement {
       top: 3px;
       left: 24px;
     }
+
+    span {
+      margin: 0px 10px;
+      color: var(--text-color-primary);
+      padding: 6px 10px;
+      background: var(--main-card--pill-background);
+      opacity: 0.9;
+      border-radius: 6px;
+    }
+
   `;
 
   /**
@@ -200,8 +227,8 @@ export class VPNCard extends LitElement {
   static propertiesFrom(vpnState) {
     return {
       enabled: vpnState.connected,
-      name: vpnState.exitServerCity?.name,
-      flag: vpnState.exitServerCountry?.code,
+      cityName: vpnState.exitServerCity?.name,
+      countryFlag: vpnState.exitServerCountry?.code,
       connectedSince: Date.now(), // TODO: We actually dont send this from the client
     };
   }
@@ -214,7 +241,7 @@ export class VPNCard extends LitElement {
     const bag = VPNCard.propertiesFrom(vpnState);
     this.enabled = bag.enabled;
     this.cityName = bag.cityName;
-    this.countryFlag = bag.flag;
+    this.countryFlag = bag.countryFlag;
     this.connectedSince = bag.connectedSince;
   }
 }

--- a/src/ui/browserAction/popup.css
+++ b/src/ui/browserAction/popup.css
@@ -15,3 +15,7 @@ body {
 section {
   background-color: var(--panel-bg-color);
 }
+
+main {
+  padding: var(--padding-default);
+}

--- a/src/ui/browserAction/popup.html
+++ b/src/ui/browserAction/popup.html
@@ -21,15 +21,17 @@
   </head>
   <body>
     <stack-view>
-      <main>
+      <section>
         <vpn-titlebar title="Mozilla VPN">
           <img slot="right" src="../../assets/img/settings-cog.svg" />
         </vpn-titlebar>
-        <vpn-card></vpn-card>
-        <hr />
-        <p>Current location</p>
-        <button id="selectLocation">Toronto</button>
-      </main>
+        <main>
+          <vpn-card></vpn-card>
+          <hr />
+          <p>Current location</p>
+          <button id="selectLocation">Toronto</button>
+        </main>
+      </section>
     </stack-view>
   </body>
 </html>

--- a/src/ui/browserAction/popup.js
+++ b/src/ui/browserAction/popup.js
@@ -23,10 +23,7 @@ const applyToMainPanel = (state) => {
     console.error("Main panel not found?!");
     return;
   }
-  const panelState = VPNCard.propertiesFrom(state);
-  panel.enabled = panelState.enabled;
-  enabled = panelState.enabled;
-  panel.connectedSince = panelState.connectedSince;
+  panel.apply(state);
 };
 
 /** @type {VPNState} */

--- a/src/ui/variables.css
+++ b/src/ui/variables.css
@@ -10,6 +10,7 @@
   --color-enabled: #3fe1b0;
   --main-card-background: #321c64;
   --main-card-text-color: white;
+  --main-card--pill-background: lch(from var(--main-card-background) calc(l + 15) c h);
   --padding-default: 16px;
 }
 

--- a/src/ui/variables.css
+++ b/src/ui/variables.css
@@ -6,10 +6,11 @@
 :root {
   --window-width: 352px;
   --window-height: 448px;
-  --font-family: "Segoe UI";
+  --font-family: "Arial", sans-serif;
   --color-enabled: #3fe1b0;
   --main-card-background: #321c64;
   --main-card-text-color: white;
+  --padding-default: 16px;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/tests/jest/background/vpncontroller/state.test.mjs
+++ b/tests/jest/background/vpncontroller/state.test.mjs
@@ -4,6 +4,8 @@ import {
   StateVPNEnabled,
   VPNState,
   StateVPNUnavailable,
+  Server,
+  ServerCity,
 } from "../../../../src/background/vpncontroller/states";
 
 describe("VPN State Machine", () => {
@@ -43,5 +45,21 @@ describe("VPN State Machine", () => {
     expect(new StateVPNDisabled(testState).loophole).toBe(false);
     expect(new StateVPNUnavailable(testState).loophole).toBe(false);
     expect(new VPNState(testState).loophole).toBe(false);
+  });
+  test("The ExitServer Field is Set in 'Enabled' and Removed on Other states", () => {
+    const testCity = new ServerCity();
+    testCity.code = "de";
+    testCity.name = "Berlino";
+    testCity.servers = [];
+    const testState = new StateVPNEnabled(null, "aaa", testCity);
+
+    expect(testState.exitServerCity.code).toBe(testCity.code);
+
+    expect(new StateVPNEnabled(testState).exitServerCity.code).toBe(
+      testState.exitServerCity.code
+    );
+    expect(new StateVPNDisabled(testState).exitServerCity.code).toBe("");
+    expect(new StateVPNUnavailable(testState).exitServerCity.code).toBe("");
+    expect(new VPNState(testState).exitServerCity.code).toBe("");
   });
 });


### PR DESCRIPTION
- Added the "Current server" footer to the main panel. 
- VPN state now contains the Current selected Exit Country+City (the one selected in the app) 

Also adds a diy "normalize thing" we can put into lit components, to address the comment. 

Nooot quite pixel perfect but for the demo okay. 


PR: 
![image](https://github.com/user-attachments/assets/de132445-7826-4638-a92b-e670968ece81)
