### PR TITLE
Add a Component that will Reload Tabs if needed

### DIFF
--- a/src/background/main.js
+++ b/src/background/main.js
@@ -11,6 +11,7 @@ import { ToolbarIconHandler } from "./toolbarIconHandler.js";
 import { VPNController } from "./vpncontroller/index.js";
 
 import { expose } from "../shared/ipc.js";
+import { TabReloader } from "./tabReloader.js";
 const log = Logger.logger("Main");
 
 class Main {
@@ -28,6 +29,7 @@ class Main {
   );
   tabHandler = new TabHandler(this, this.vpnController, this.proxyHandler);
   toolbarIconHandler = new ToolbarIconHandler(this, this.vpnController);
+  tabReloader = new TabReloader(this, this.proxyHandler);
 
   async init() {
     log("Hello from the background script!");

--- a/src/background/proxyHandler/proxyHandler.js
+++ b/src/background/proxyHandler/proxyHandler.js
@@ -34,11 +34,20 @@ export class ProxyHandler extends Component {
   controllerState;
 
   #mSiteContexts = property(new Map());
+  #lastChangedOrigin = property("");
   currentPort;
 
   /** @type {IBindable<Map<String, SiteContext>>} */
   get siteContexts() {
     return this.#mSiteContexts.readOnly;
+  }
+  /**
+   * Returns a bindable containing the last origin
+   * whos siteContext got changed
+   * @type {IBindable<String>}
+   * */
+  get lastChangedOrigin() {
+    return this.#lastChangedOrigin.readOnly;
   }
 
   async init() {
@@ -72,6 +81,7 @@ export class ProxyHandler extends Component {
 
     const siteContexts = await this.#mSiteContexts.value;
     siteContexts.set(siteContext.origin, { ...siteContext });
+    this.#lastChangedOrigin.set(siteContext.origin);
     return this.#setSiteContexts(siteContexts);
   }
   async #getSiteContexts() {
@@ -91,6 +101,7 @@ export class ProxyHandler extends Component {
   async removeContextForOrigin(origin) {
     const siteContexts = this.#mSiteContexts.value;
     siteContexts.delete(origin);
+    this.#lastChangedOrigin.set(origin);
     return this.#setSiteContexts(siteContexts);
   }
 

--- a/src/background/tabReloader.js
+++ b/src/background/tabReloader.js
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Utils } from "../shared/utils.js";
+import { Component } from "./component.js";
+import { ProxyHandler } from "./proxyHandler/proxyHandler.js";
+
+/**
+ * This Class Listens to Changes to the ProxyHandler.SiteContext
+ * rules.
+ * It will query the Open tabs and either Reload or Discard the
+ * Tab to make sure the new SiteContext is Respected.
+ *
+ * Impacted tabs that are not Active will be discarded
+ * so that the next time the user opens the Tab we will reload it
+ *
+ * Active Tabs will be reloaded instantly.
+ *
+ * Tabs that play Audio/Video i.e a Zoom Call, Youtube Video etc
+ * will not be reloaded/discarded.
+ *
+ */
+export class TabReloader extends Component {
+  /**
+   *
+   * @param {*} receiver
+   * @param {ProxyHandler} proxyHandler
+   */
+  constructor(receiver, proxyHandler) {
+    super(receiver);
+    this.proxyHandler = proxyHandler;
+  }
+  async init() {
+    this.proxyHandler.lastChangedOrigin.subscribe(TabReloader.onOriginChanged);
+  }
+
+  static async onOriginChanged(origin = "") {
+    const loadedTabs = await browser.tabs.query({
+      // If discarded, the next activation will reload it anyway.
+      discarded: false,
+    });
+    const relevantTabs = loadedTabs.filter(TabReloader.matches(origin));
+    if (relevantTabs.length == 0) {
+      return;
+    }
+    relevantTabs.filter(TabReloader.needsDiscard).forEach((tab) => {
+      browser.tabs.discard(tab.id);
+    });
+    relevantTabs.filter(TabReloader.needsReload).forEach((tab) => {
+      browser.tabs.reload(tab.id);
+    });
+  }
+
+  /**
+   * Checks if a tab matches an hostname
+   * @param {String} hostname - The hostname
+   * @returns {($1:browser.tabs.Tab)=>boolean} - A filter function checking tab hostname
+   */
+  static matches(hostname = "") {
+    /**
+     * @param {browser.tabs.Tab} tab
+     * @returns {boolean}
+     */
+    return (tab) => {
+      if (hostname === "") {
+        return false;
+      }
+      const tabURL = Utils.getFormattedHostname(tab.url);
+      return tabURL === hostname;
+    };
+  }
+
+  /**
+   * Returns true if the Tab Should be discarded if
+   * the SiteContext Rule for the Tab Changes
+   * @param {browser.tabs.Tab} tab - The Tab to check
+   * @returns {Boolean}
+   */
+  static needsDiscard(tab) {
+    return !tab.discarded && !tab.audible && !tab.active;
+  }
+  /**
+   * Returns true if the Tab Should be Reloaded if
+   * the SiteContext Rule for the Tab Changes
+   * @param {browser.tabs.Tab} tab - The Tab to check
+   * @returns {Boolean}
+   */
+  static needsReload(tab) {
+    return tab.active && !tab.audible && !tab.discarded;
+  }
+}

--- a/tests/jest/background/tabreloader.test.mjs
+++ b/tests/jest/background/tabreloader.test.mjs
@@ -1,0 +1,94 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed wtesth this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, test, jest } from "@jest/globals";
+
+import { TabReloader } from "../../../src/background/tabReloader";
+describe("TabReloader", () => {
+  describe("TabReloader::matches", () => {
+    /**
+     * @returns {browser.tabs.Tab}
+     */
+    const makeTab = (host) => {
+      return {
+        url: `https://${host}/index.html`,
+      };
+    };
+    test("Returns a function", () => {
+      const func = TabReloader.matches("");
+      expect(typeof func).toBe("function");
+    });
+    test("Empty matcher will match nothing ", () => {
+      const tabs = [makeTab("hello.com"), makeTab("world.com")];
+      const out = tabs.filter(TabReloader.matches());
+      expect(out.length).toBe(0);
+    });
+    test("Empty matcher will match nothing ", () => {
+      const tabs = [makeTab("hello.com"), makeTab("world.com")];
+      const out = tabs.filter(TabReloader.matches());
+      expect(out.length).toBe(0);
+    });
+    test("matcher will match a hostname ", () => {
+      const tabs = [makeTab("hello.com"), makeTab("world.com")];
+      const out = tabs.filter(TabReloader.matches("world.com"));
+      expect(out.length).toBe(1);
+    });
+  });
+  describe("TabReloader::needsDiscard", () => {
+    /**
+     * @returns {browser.tabs.Tab}
+     */
+    const makeTestCase = (result, discarded, active, audible) => {
+      return [{ discarded, active, audible }, result];
+    };
+    const testCases = [
+      // Not discareded Background tab => true
+      makeTestCase(true, false, false, false),
+      // Not discarded Background tab but playing audio => false
+      makeTestCase(false, false, false, true),
+      // Active Tab => false (will reload)
+      makeTestCase(false, false, true, false),
+      // Active Tab && Playing audio  => false
+      makeTestCase(false, false, true, true),
+      // Discarded Tabs => False
+      makeTestCase(false, true, false, false),
+      makeTestCase(false, true, false, true),
+      makeTestCase(false, true, true, false),
+      makeTestCase(false, true, true, true),
+    ];
+    testCases.forEach(([o, expected]) => {
+      test(`needsDiscard(${JSON.stringify(o)}) => ${expected}`, () => {
+        expect(TabReloader.needsDiscard(o)).toBe(expected);
+      });
+    });
+  });
+  describe("TabReloader::needsReload", () => {
+    /**
+     * @returns {browser.tabs.Tab}
+     */
+    const makeTestCase = (result, discarded, active, audible) => {
+      return [{ discarded, active, audible }, result];
+    };
+    const testCases = [
+      // Not discareded Background tab => true
+      makeTestCase(false, false, false, false),
+      // Not discarded Background tab but playing audio => false
+      makeTestCase(false, false, false, true),
+      // Active Tab => true
+      makeTestCase(true, false, true, false),
+      // Active Tab && Playing audio  => *FALSE*
+      makeTestCase(false, false, true, true),
+      // Discarded Tabs => False
+      makeTestCase(false, true, false, false),
+      makeTestCase(false, true, false, true),
+      makeTestCase(false, true, true, false),
+      makeTestCase(false, true, true, true),
+    ];
+    testCases.forEach(([o, expected]) => {
+      test(`needsReload(${JSON.stringify(o)}) => ${expected}`, () => {
+        expect(TabReloader.needsReload(o)).toBe(expected);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This add's a class that will listen to changes in proxyHandler. It will reload active impacted tabs by the change. Not active tabs will be discarded, and reloaded on the next activation. (As we probably dont want to reload all of my 100 jira tabs that i have not been touching). 
Also this will not reload "audible" tabs, so that a "background youtube tab" is not reloaded if you change another youtube rule. 