### PR TITLE
Add drop shadow to vpn-card

### DIFF
--- a/src/components/vpncard.js
+++ b/src/components/vpncard.js
@@ -133,9 +133,11 @@ export class VPNCard extends LitElement {
       align-items: flex-start;
       justify-content: space-between;
       flex-direction: column;
+      box-shadow: var(--box-shadow-off);
     }
     .box.on {
       background: var(--main-card-background);
+      box-shadow: var(--box-shadow-on);
     }
     main,
     footer {
@@ -283,6 +285,7 @@ export class VPNCardPlaceHolder extends LitElement {
       align-items: center;
       justify-content: space-between;
       flex-direction: row;
+      box-shadow: var(--box-shadow-off);
     }
     .infobox {
       flex: 4;

--- a/src/ui/variables.css
+++ b/src/ui/variables.css
@@ -49,6 +49,8 @@
   --padding-default: 16px;
   --button-transition: background-color 0.2s ease;
   --button-border-radius: 5px;
+  --box-shadow-on: rgba(0, 0, 0, 0.28) 2px 2px 4px;
+  --box-shadow-off: rgba(0, 0, 0, 0.06) 2px 2px 7px;
 }
 
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
Tiniest PR to add a drop-shadow to vpn-card. 
<img width="372" alt="Screenshot 2024-09-02 at 3 06 46 PM" src="https://github.com/user-attachments/assets/9b9c37d7-6862-4139-b838-4a8380086b5b">
<img width="372" alt="Screenshot 2024-09-02 at 3 06 38 PM" src="https://github.com/user-attachments/assets/bc2bb7df-fd31-40a3-8df8-5427b3c39d2d">
<img width="365" alt="Screenshot 2024-09-02 at 3 24 07 PM" src="https://github.com/user-attachments/assets/785c2c8c-8418-4294-a25f-a5d1e9b952ff">
<img width="362" alt="Screenshot 2024-09-02 at 3 23 58 PM" src="https://github.com/user-attachments/assets/03ae0561-7685-45cc-9b9e-f5c571b13b27">
