### PR TITLE
Vertically center checkbox with first line of label

### DIFF
--- a/src/ui/browserAction/popupPage.js
+++ b/src/ui/browserAction/popupPage.js
@@ -372,6 +372,7 @@ export class BrowserActionPopup extends LitElement {
       height: 20px;
       border: 1px solid var(--border-color);
       background-color: var(--panel-bg-color);
+      margin-block: 0 auto;
     }
     input + p {
       margin-left: var(--padding-default);


### PR DESCRIPTION
Fixes a tiny checkbox alignment nit I noticed while doing other things.
<img width="396" alt="Screenshot 2024-09-02 at 9 01 13 PM" src="https://github.com/user-attachments/assets/72d5cbf4-43dc-43fd-8116-6fbb7342b335">
