### PR TITLE
Persist reset preferences button

### DIFF
--- a/src/ui/browserAction/popupPage.js
+++ b/src/ui/browserAction/popupPage.js
@@ -226,9 +226,6 @@ export class BrowserActionPopup extends LitElement {
     hasSiteContext = false
   ) {
     const pageLocationPicker = (() => {
-      if (siteContext.excluded) {
-        return null;
-      }
       return html`
         <h2 class="select-location-title">${tr("titleServerList")}</h2>
         <button
@@ -263,11 +260,9 @@ export class BrowserActionPopup extends LitElement {
         <p>${tr("exludePageFor", siteContext.origin)}</p>
       </div>
       ${pageLocationPicker}
-      ${hasSiteContext
-        ? html`<button id="selectLocation" @click=${removeSiteContext}>
-            ${tr("resetPageSettings")}
-          </button>`
-        : null}
+      <button id="reset-pref" @click=${removeSiteContext} class="${ hasSiteContext ? "" : "disabled"} ">
+        ${tr("resetPageSettings")}
+      </button>   
     `;
   }
   static backBtn(back) {
@@ -300,6 +295,22 @@ export class BrowserActionPopup extends LitElement {
 
   static styles = css`
     ${fontSizing}${resetSizing}${ghostButtonStyles}
+    :root {
+      --button-reset-border-default: rgba(0, 96, 223, 1);
+      --button-reset-border-hover: rgba(2, 80, 187, 1);
+      --button-reset-border-active: rgba(5, 64, 150, 1);
+      --button-reset-border-disabled: rgba(0, 96, 223, 1);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --button-reset-border-default: rgba(0, 221, 255, 1);
+        --button-reset-border-hover: rgba(128, 235, 255, 1);
+        --button-reset-border-active: rgba(170, 242, 255, 1);
+        --button-reset-border-disabled: rgba(0, 221, 255, 1);
+      }
+    }
+    
     section {
       background-color: var(--panel-bg-color);
     }
@@ -372,22 +383,47 @@ export class BrowserActionPopup extends LitElement {
       height: 20px;
       border: 1px solid var(--border-color);
       background-color: var(--panel-bg-color);
+      margin-block: 0 auto;
     }
+
     input + p {
       margin-left: var(--padding-default);
     }
 
     button {
       width: 100%;
-      border-radius: 4px;
+      border-radius: 4px; 
       padding: 8px, 16px, 8px, 16px;
       size: 16px;
       font-weight: 600;
-      border: 1px solid var(--action-button-color);
+      border-width: 2px;
+      border-style: solid;
       color: var(--action-button-color);
       background-color: transparent;
       padding: 10px;
-      margin-top: var(--padding-default);
+      margin-block: 0px var(--padding-default);
+    }
+
+    #reset-pref {
+      border-color: var(--button-reset-border-default);
+      transition: border-color 0.2s ease;
+    }
+
+    #reset-pref:hover {
+      border-color: var(--button-reset-border-hover);
+    }
+
+    #reset-pref:focus {
+      outline: var(--focus-outline);
+      outline-offset: var(--focus-outline-offset);
+    }
+
+    #reset-pref.disabled:focus {
+      outline: none;
+    }
+
+    #reset-pref:active {
+      border-color: var(--button-reset-border-active);
     }
 
     .disabled {

--- a/src/ui/pageAction/pageAction.js
+++ b/src/ui/pageAction/pageAction.js
@@ -140,7 +140,7 @@ export class PageActionPopup extends LitElement {
       margin-inline: auto 0;
       font-weight: 500;
       padding: 4px 16px;
-      min-block-size: 32px;
+      min-block-size: 40px;
       border-radius: 4px;
       border: none;
       background: none;

--- a/src/ui/variables.css
+++ b/src/ui/variables.css
@@ -32,7 +32,7 @@
 
 :root {
   --window-width: 352px;
-  --window-max-height: 399px;
+  --window-max-height: 454px;
 
   --font-family: "Inter Regular";
   --font-family-semi-bold: "Inter Semi Bold";
@@ -59,6 +59,8 @@
     --text-color-primary: white;
     --text-color-invert: #3d3d3d;
     --button-ghost-bg-color: #ffffff;
+
+    --focus-outline: 3px solid #007aff;
   }
 }
 
@@ -73,5 +75,8 @@
     --text-color-invert: white;
     --border-color: lch(from var(--panel-bg-color) calc(l - 15) c h);
     --button-ghost-bg-color: #3d3d3d;
+
+    --focus-outline: 3px solid #cbe5fc;
+    --focus-outline-offset: 1px; 
   }
 }


### PR DESCRIPTION
Glancing through the specs, I _think_ we are supposed to persist reset button visibility when there are no active site prefs. Lots of TODOs here though because I couldn't find UI states (hover, focus, etc) for that button and I need some Lit help to bind where or not the button is enabled/disabled to whether or not there is an origin for a given site (ie, the button should react to both checking and unchecking the checkbox multiple times). 