### PR TITLE
basti/refactorVPNController

### DIFF
--- a/src/background/vpncontroller/index.js
+++ b/src/background/vpncontroller/index.js
@@ -2,11 +2,5 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export {
-  VPNState,
-  StateVPNEnabled,
-  StateVPNUnavailable,
-  StateVPNDisabled,
-  REQUEST_TYPES,
-} from "./states.js";
-export { VPNController } from "./vpncontroller.js";
+export * from "./states.js";
+export * from "./vpncontroller.js";

--- a/src/background/vpncontroller/vpncontroller.js
+++ b/src/background/vpncontroller/vpncontroller.js
@@ -6,15 +6,21 @@
 import { Component } from "../component.js";
 import { Logger } from "../logger.js";
 
-import { property } from "../../shared/property.js";
+import {
+  IBindable,
+  WritableProperty,
+  property,
+} from "../../shared/property.js";
 import { PropertyType } from "../../shared/ipc.js";
 
 import {
   VPNState,
-  StateVPNEnabled,
   StateVPNUnavailable,
+  StateVPNEnabled,
   StateVPNDisabled,
   REQUEST_TYPES,
+  ServerCountry,
+  vpnStatusResponse,
 } from "./states.js";
 
 const log = Logger.logger("TabHandler");
@@ -29,14 +35,23 @@ const log = Logger.logger("TabHandler");
 export class VPNController extends Component {
   // Things to expose to the UI
   static properties = {
+    servers: PropertyType.Bindable,
+    isExcluded: PropertyType.Bindable,
     state: PropertyType.Bindable,
     postToApp: PropertyType.Function,
-    isolationKey: PropertyType.Value,
+    isolationKey: PropertyType.Bindable,
   };
 
   get state() {
     return this.#mState.readOnly;
   }
+  get servers() {
+    return this.#mServers;
+  }
+  get isExcluded() {
+    return this.#isExcluded;
+  }
+
   async initNativeMessaging() {
     log("initNativeMessaging");
     if (this.#port && this.#port.error === null) {
@@ -62,16 +77,29 @@ export class VPNController extends Component {
       // invalid proxy connection.
       this.#port.onDisconnect.addListener(() => {
         this.#increaseIsolationKey();
-        this.#mState.value = new StateVPNUnavailable(this.#mState.value);
+        this.#mState.value = new StateVPNUnavailable();
       });
     } catch (e) {
       log(e);
-      this.#mState.value = new StateVPNUnavailable(this.#mState.value);
+      this.#mState.value = new StateVPNUnavailable();
     }
   }
 
   async init() {
-    this.#mState.value = await VPNState.fromStorage();
+    this.#mState.value = new StateVPNUnavailable();
+    this.#mServers.value = await fromStorage(
+      browser.storage.local,
+      MOZILLA_VPN_SERVERS_KEY,
+      []
+    );
+    this.#mServers.subscribe((newServers) => {
+      putIntoStorage(
+        newServers,
+        browser.storage.local,
+        MOZILLA_VPN_SERVERS_KEY
+      );
+    });
+
     this.initNativeMessaging();
   }
   /**
@@ -88,7 +116,7 @@ export class VPNController extends Component {
       log(e);
       // @ts-ignore
       if (e.toString() === "Attempt to postMessage on disconnected port") {
-        this.#mState.value = new StateVPNUnavailable(this.#mState.value);
+        this.#mState.value = new StateVPNUnavailable();
       }
     }
   }
@@ -104,85 +132,18 @@ export class VPNController extends Component {
     }
     switch (response.t) {
       case "servers":
-        // @ts-ignore
-        const newState = new this.#mState.value.constructor({
-          ...this.#mState.value,
-          servers: response.servers.countries,
-        });
-        VPNState.putIntoStorage(newState);
-        this.#mState.value = newState;
+        this.#mServers.set(response.servers.countries);
         break;
       case "disabled_apps":
-        // Todo: THIS IS HACKY
-        // We need to find out if the excluded firefox
-        const app_paths = [
-          ["Firefox Nightly", "firefox.exe"],
-          ["Firefox", "firefox.exe"],
-          ["Firefox Developer Edition", "firefox.exe"],
-        ];
-        const intersects = (a, b) => {
-          return a.filter(Set.prototype.has, new Set(b)).length == 0;
-        };
-
-        let apps = response["disabled_apps"];
-        apps ??= [];
-        const isFirefoxExcluded = apps.some((path) => {
-          const path_components = path.split("[\\/]"); // Split \\ and /
-          return app_paths.some((searchPath) => {
-            return intersects(path_components, searchPath);
-          });
-        });
-        if (isFirefoxExcluded) {
-          this.#mState.value =
-            // @ts-ignore
-            new this.#mState.value.constructor({
-              ...this.#mState,
-              isExcluded: true,
-            });
-          return;
-        }
+        this.#isExcluded.set(isSplitTunnled(response));
         break;
       case "status":
-        const status = response.status;
-        const controllerState = status.vpn;
-        const connectedSince = (() => {
-          if (!status.connectedSince) {
-            return 0;
-          }
-          return parseInt(status.connectedSince);
-        })();
-        const exit_city_name = status.location["exit_city_name"];
-        const exit_country_code = status.location["exit_country_code"];
-        const exitServerCountry = this.#mState.value.servers.find(
-          (country) => country.code === exit_country_code
-        );
-        const exitServerCity = exitServerCountry?.cities.find(
-          (city) => city.name === exit_city_name
-        );
-
-        const next_state = {
-          ...this.#mState.value,
-          exitServerCity,
-          exitServerCountry,
-        };
-
-        if (controllerState === "StateOn") {
-          this.#mState.value = new StateVPNEnabled(
-            next_state,
-            status.localProxy?.url,
-            connectedSince
-          );
-          return;
+        const newStatus = fromVPNStatusResponse(response, this.#mServers.value);
+        if (newStatus) {
+          this.#mState.set(newStatus);
+          // Let's increase the network key isolation at any vpn status change.
+          this.#increaseIsolationKey();
         }
-        if (
-          controllerState === "StateOff" ||
-          controllerState === "StateDisconnecting"
-        ) {
-          this.#mState.value = new StateVPNDisabled(next_state);
-          return;
-        }
-        // Let's increase the network key isolation at any vpn status change.
-        this.#increaseIsolationKey();
         break;
       default:
         throw Error("Unexpeted Message type: " + response.t);
@@ -195,7 +156,7 @@ export class VPNController extends Component {
     // We can only get 2 types of messages right now: client-down/up
     if (response.status && response.status === "vpn-client-down") {
       if (this.#mState.value.alive) {
-        this.#mState.value = new StateVPNUnavailable(this.#mState.value);
+        this.#mState.value = new StateVPNUnavailable();
       }
       return;
     }
@@ -218,19 +179,131 @@ export class VPNController extends Component {
    * tcp handle (which is now invalid) is not reused.
    *
    * @readonly
-   * @type {number}
+   * @type {IBindable<Number>}
    */
   get isolationKey() {
     return this.#isolationKey;
   }
 
   #increaseIsolationKey() {
-    ++this.#isolationKey;
+    this.#isolationKey.set(this.#isolationKey.value++);
   }
 
   /** @type {browser.runtime.Port?} */
   #port = null;
-  #isolationKey = 0;
+  #isolationKey = property(0);
 
-  #mState = property(new VPNState(null));
+  #mState = property(new VPNState());
+  /** @type {WritableProperty<Array<ServerCountry>>} */
+  // @ts-ignore
+  #mServers = property([]);
+
+  #isExcluded = property(false);
+}
+
+export function isSplitTunnled(
+  response = {
+    t: "disabled_apps",
+    disabled_apps: [""],
+  }
+) {
+  if (response.t != "disabled_apps") {
+    throw new Error("passed an invalid response");
+  }
+  // Todo: THIS IS STILL HACKY
+  const search_terms = ["firefox.exe", "firefox"];
+  let apps = response.disabled_apps;
+  apps ??= [];
+  const isFirefoxExcluded = apps.some((path) => {
+    return search_terms.some((searchPath) => {
+      return path.endsWith(searchPath);
+    });
+  });
+  return isFirefoxExcluded;
+}
+
+const MOZILLA_VPN_SERVERS_KEY = "mozillaVpnServers";
+
+/**
+   * fetches data from storage and then
+ 
+   * @template T
+   * @param {browser.storage.StorageArea} storage - The storage area to look for
+   * @param {String} key - The key to put the state in
+   * @param {T} defaultValue - The Default value, in case it does not exist. 
+   * @returns {Promise<T>} - Returns a copy of the state, or the same in case of missing data.
+   */
+async function fromStorage(
+  storage = browser.storage.local,
+  key = MOZILLA_VPN_SERVERS_KEY,
+  defaultValue
+) {
+  const { mozillaVpnServers } = await storage.get(key);
+  if (typeof mozillaVpnServers === "undefined") {
+    return defaultValue;
+  }
+  // @ts-ignore
+  return mozillaVpnServers;
+}
+
+/**  data into storage, to make sure we can recreate it next time using
+ * @param {any} data - The state to replicate
+ * @param {browser.storage.StorageArea} storage - The storage area to look for
+ * @param {String} key - The key to put the state in
+ */
+function putIntoStorage(
+  data = {},
+  storage = browser.storage.local,
+  key = MOZILLA_VPN_SERVERS_KEY
+) {
+  // @ts-ignore
+  storage.set({ [key]: data });
+}
+
+/**
+ * Take a VPN Status Response message, and returns an Extension State Object.
+ * @param {vpnStatusResponse} response - What the VPN sent
+ * @param {Array<ServerCountry>} serverList - The Current Serverlist
+ * @returns
+ */
+
+export function fromVPNStatusResponse(
+  response = new vpnStatusResponse(),
+  serverList = []
+) {
+  if (response.t != "status") {
+    return;
+  }
+  const status = response.status;
+  const controllerState = status.vpn;
+  const connectedSince = (() => {
+    if (!status.connectedSince) {
+      return 0;
+    }
+    return parseInt(status.connectedSince);
+  })();
+  const exit_city_name = status.location["exit_city_name"];
+  const exit_country_code = status.location["exit_country_code"];
+  const exitServerCountry = serverList.find(
+    (country) => country.code === exit_country_code
+  );
+  const exitServerCity = exitServerCountry?.cities.find(
+    (city) => city.name === exit_city_name
+  );
+
+  if (controllerState === "StateOn") {
+    return new StateVPNEnabled(
+      exitServerCity,
+      exitServerCountry,
+      status.localProxy?.url,
+      connectedSince
+    );
+  }
+  if (
+    controllerState === "StateOff" ||
+    controllerState === "StateDisconnecting"
+  ) {
+    return new StateVPNDisabled(exitServerCity, exitServerCountry);
+  }
+  return;
 }

--- a/src/background/vpncontroller/vpncontroller.js
+++ b/src/background/vpncontroller/vpncontroller.js
@@ -225,7 +225,7 @@ export function isSplitTunnled(
 const MOZILLA_VPN_SERVERS_KEY = "mozillaVpnServers";
 
 /**
-   * fetches data from storage and then
+   * fetches data from storage
  
    * @template T
    * @param {browser.storage.StorageArea} storage - The storage area to look for

--- a/src/shared/property.js
+++ b/src/shared/property.js
@@ -40,7 +40,7 @@ export class IBindable {
  *
  * @template T
  */
-class Property extends IBindable {
+export class WritableProperty extends IBindable {
   /**
    * Constructs a Property<T> with an initial Value
    * @param {T} initialvalue
@@ -141,7 +141,7 @@ export class ReadOnlyProperty extends IBindable {
 class LazyComputedProperty {
   /**
    * Constructs a Bindable<T> from a Property
-   * @param {Property<P>} parent - The proptery to read from
+   * @param {WritableProperty<P>} parent - The proptery to read from
    * @param {(arg0: (P|null) )=>T} transform - The function to apply
    */
   constructor(parent, transform) {
@@ -189,7 +189,7 @@ class LazyComputedProperty {
   }
 
   /**
-   * @type {Property<P>}
+   * @type {WritableProperty<P>}
    * The Parent Property
    */
   #parent;
@@ -212,16 +212,16 @@ class LazyComputedProperty {
 /**
  * @template T
  * @param {T} value - Initial value of the Property
- * @returns {Property<T>} - A Property
+ * @returns {WritableProperty<T>} - A Property
  */
 export const property = (value) => {
-  return new Property(value);
+  return new WritableProperty(value);
 };
 
 /**
  * @template T
  * @template P
- * @param {Property<P>} property - Callback when the value changes
+ * @param {WritableProperty<P>} property - Callback when the value changes
  * @param {(arg0: P?)=>T} transform - Called with the Property Value, must return the transformed value
  * @returns {LazyComputedProperty<T,P>} - A Function to stop the subscription
  */

--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -57,15 +57,11 @@ export const Utils = {
       return false;
     }
   },
-  nameFor: (
-    countryCode = "de",
-    cityCode = "ber",
-    serverList = []
-  ) => {
+  nameFor: (countryCode = "de", cityCode = "ber", serverList = []) => {
     if (!serverList) {
       return "";
     }
-    if(serverList.length ===0){
+    if (serverList.length === 0) {
       return "";
     }
     return serverList

--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -60,9 +60,12 @@ export const Utils = {
   nameFor: (
     countryCode = "de",
     cityCode = "ber",
-    serverList = [new ServerCountry()]
+    serverList = []
   ) => {
     if (!serverList) {
+      return "";
+    }
+    if(serverList.length ===0){
       return "";
     }
     return serverList

--- a/src/ui/browserAction/popupPage.js
+++ b/src/ui/browserAction/popupPage.js
@@ -180,11 +180,7 @@ export class BrowserActionPopup extends LitElement {
       this.openServerList.bind(this),
       toggleExcludeWebsite,
       (ctx = new SiteContext()) => {
-        return Utils.nameFor(
-          ctx.countryCode,
-          ctx.cityCode,
-          this.servers
-        );
+        return Utils.nameFor(ctx.countryCode, ctx.cityCode, this.servers);
       },
       resetSitePrefrences,
       this._siteContext !== null

--- a/src/ui/browserAction/popupPage.js
+++ b/src/ui/browserAction/popupPage.js
@@ -46,6 +46,7 @@ import {
  */
 export class BrowserActionPopup extends LitElement {
   static properties = {
+    servers: { type: Object },
     vpnState: { type: Object },
     pageURL: { type: String },
     _siteContext: { type: Object },
@@ -59,6 +60,7 @@ export class BrowserActionPopup extends LitElement {
     browser.tabs.onUpdated.addListener(() => this.updatePage());
     browser.tabs.onActivated.addListener(() => this.updatePage());
     vpnController.state.subscribe((s) => (this.vpnState = s));
+    vpnController.servers.subscribe((s) => (this.servers = s));
     this.updatePage();
   }
   updatePage() {
@@ -181,7 +183,7 @@ export class BrowserActionPopup extends LitElement {
         return Utils.nameFor(
           ctx.countryCode,
           ctx.cityCode,
-          this.vpnState.servers
+          this.servers
         );
       },
       resetSitePrefrences,
@@ -207,7 +209,7 @@ export class BrowserActionPopup extends LitElement {
       }
     };
     const serverListElement = BrowserActionPopup.createServerList(
-      this.vpnState.servers,
+      this.servers,
       onSelectServerResult
     );
     this.stackView.value?.push(serverListElement).then(() => {

--- a/src/ui/pageAction/pageAction.js
+++ b/src/ui/pageAction/pageAction.js
@@ -17,7 +17,7 @@ import { fontSizing, resetSizing } from "../../components/styles.js";
  */
 export class PageActionPopup extends LitElement {
   static properties = {
-    vpnState: { type: Object },
+    servers: { type: Object },
     pageURL: { type: String },
     _siteContext: { type: Object },
   };
@@ -38,7 +38,7 @@ export class PageActionPopup extends LitElement {
       }
     });
 
-    vpnController.state.subscribe((s) => (this.vpnState = s));
+    vpnController.servers.subscribe((s) => (this.servers = s));
   }
 
   render() {
@@ -57,7 +57,7 @@ export class PageActionPopup extends LitElement {
       if (excluded) {
         return "Off";
       }
-      const servers = this.vpnState?.servers;
+      const servers = this.servers;
       return servers
         .find((sc) => sc.code === this._siteContext?.countryCode)
         ?.cities.find((c) => c.code === this._siteContext?.cityCode)?.name;

--- a/src/ui/settingsPage/settingsPage.js
+++ b/src/ui/settingsPage/settingsPage.js
@@ -27,7 +27,7 @@ export class SettingsPage extends LitElement {
     this.contexts = new Map();
     this.vpnController = getExposedObject("VPNController");
     this.vpnController.then((c) => {
-      c.state.subscribe((state) => (this.serverList = state.servers));
+      c.servers.subscribe((servers) => (this.serverList = servers));
     });
     this.proxyHandler = getExposedObject("ProxyHandler");
     this.proxyHandler.then((p) => {

--- a/tests/jest/background/vpncontroller/state.test.mjs
+++ b/tests/jest/background/vpncontroller/state.test.mjs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { describe, expect, test } from "@jest/globals";
 import {
   StateVPNDisabled,
@@ -19,58 +23,5 @@ describe("VPN State Machine", () => {
   test("Can Create all States", () => {
     const result = STATE_CONSTRUCTORS.map((state) => new state());
     expect(result.length).toBe(STATE_CONSTRUCTORS.length);
-  });
-
-  test("Can Create a State from another keeping data", () => {
-    const stateA = new VPNState();
-    // Servers is persistent, so if we call new State(oldState)
-    stateA.servers.push({ cities: [], code: "de", name: "GERMONY" });
-    stateA.isExcluded = true;
-
-    const endstate = STATE_CONSTRUCTORS.reduce(
-      (state, nextstate) => new nextstate(state),
-      stateA
-    );
-    expect(endstate.servers[0].name).toBe(stateA.servers[0].name);
-    expect(endstate.servers[0].code).toBe(stateA.servers[0].code);
-    expect(endstate.isExcluded).toBe(stateA.isExcluded);
-  });
-
-  test("The Proxy Field is Set in 'Enabled' and Removed on Other states", () => {
-    const testState = new StateVPNEnabled();
-    // Servers is persistent, so if we call new State(oldState)
-    testState.loophole = "aaa";
-
-    expect(new StateVPNEnabled(testState).loophole).toBe(testState.loophole);
-    expect(new StateVPNDisabled(testState).loophole).toBe(false);
-    expect(new StateVPNUnavailable(testState).loophole).toBe(false);
-    expect(new VPNState(testState).loophole).toBe(false);
-  });
-  test("The ExitServer Field is Set in 'Enabled' and Removed on Other states", () => {
-    const testCity = new ServerCity();
-    testCity.code = "de";
-    testCity.name = "Berlino";
-    testCity.servers = [];
-    const testState = new StateVPNEnabled(
-      {
-        exitServerCity: testCity,
-      },
-      "aaa"
-    );
-
-    expect(testState.exitServerCity.code).toBe(testCity.code);
-
-    expect(new StateVPNEnabled(testState).exitServerCity.code).toBe(
-      testState.exitServerCity.code
-    );
-    expect(new StateVPNDisabled(testState).exitServerCity.code).toBe(
-      testState.exitServerCity.code
-    );
-    expect(new StateVPNUnavailable(testState).exitServerCity.code).toBe(
-      testState.exitServerCity.code
-    );
-    expect(new VPNState(testState).exitServerCity.code).toBe(
-      testState.exitServerCity.code
-    );
   });
 });

--- a/tests/jest/background/vpncontroller/vpncontroller.test.mjs
+++ b/tests/jest/background/vpncontroller/vpncontroller.test.mjs
@@ -1,0 +1,155 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, test } from "@jest/globals";
+import {
+  fromVPNStatusResponse,
+  isSplitTunnled,
+  ServerCity,
+  ServerCountry,
+  vpnStatusResponse,
+} from "../../../../src/background/vpncontroller";
+
+describe("isSplitTunneled", () => {
+  const cases = [
+    { res: true, path: "/soo/bar/Firefox Nightly/firefox.exe" },
+    { res: true, path: "/soo/bar/Firefox Developer Edition/firefox.exe" },
+    { res: true, path: "/soo/bar/Firefox/firefox.exe" },
+    { res: true, path: "/soo/bar/Firefox Nightly/firefox" },
+    { res: true, path: "/soo/bar/Firefox Developer Edition/firefox" },
+    { res: true, path: "/soo/bar/Firefox/firefox" },
+    { res: false, path: "/soo/bar/Waterfox/Waterfox" },
+  ];
+  cases.forEach((c) => {
+    it(`Should handle ${c.path}`, () => {
+      expect(
+        isSplitTunnled({
+          t: "disabled_apps",
+          disabled_apps: [c.path],
+        })
+      ).toBe(c.res);
+    });
+  });
+  it(`No apps split tunneled`, () => {
+    expect(
+      isSplitTunnled({
+        t: "disabled_apps",
+        disabled_apps: [],
+      })
+    ).toBe(false);
+  });
+  it(`Has default args`, () => {
+    expect(isSplitTunnled()).toBe(false);
+  });
+  it(`Throws with wrong args`, () => {
+    try {
+      isSplitTunnled({
+        t: "malformed_apps",
+        disabled_apps: [],
+      });
+      // Unreachable Hopefully
+      expect(null).toBe(true);
+    } catch (error) {
+      expect(error.toString()).toContain("passed an invalid response");
+    }
+  });
+});
+
+describe("fromVPNStatusResponse", () => {
+  const makeCountry = (code, name) => {
+    const out = new ServerCountry();
+    out.code = code;
+    out.name = name;
+    return out;
+  };
+  const makeCity = (code, name) => {
+    const x = new ServerCity();
+    x.code = code;
+    x.name = name;
+    return x;
+  };
+
+  const list = (() => {
+    const l = [];
+    const germany = makeCountry("de", "germany");
+    germany.cities.push(makeCity("ber", "berlin"));
+    l.push(germany);
+    const mordor = makeCountry("mor", "mordor");
+    mordor.cities.push("oh", "Actually no idea what the name would be");
+    l.push(mordor);
+    return l;
+  })();
+
+  it("fails on a non status response", () => {
+    const msg = new vpnStatusResponse();
+    msg.t = "no status";
+    expect(fromVPNStatusResponse(msg)).toBeUndefined();
+  });
+
+  it("It can Create a StateOff Status", () => {
+    const msg = new vpnStatusResponse();
+    msg.status.vpn = "StateOff";
+    msg.status.location.entry_city_name = "berlin";
+    msg.status.location.entry_country_code = "de";
+    msg.status.location.exit_country_code = "mor";
+    msg.status.location.exit_city_name =
+      "Actually no idea what the name would be";
+
+    const result = fromVPNStatusResponse(msg, list);
+    expect(result.exitServerCity).toBe(list[1][0]);
+    expect(result.exitServerCountry).toBe(list[1]);
+    expect(result.connected).toBe(false);
+    expect(result.state).toBe("Disabled");
+  });
+
+  it("It creates a StateOff Status when Disconnecting", () => {
+    const msg = new vpnStatusResponse();
+    msg.status.vpn = "StateDisconnecting";
+    msg.status.location.entry_city_name = "berlin";
+    msg.status.location.entry_country_code = "de";
+    msg.status.location.exit_country_code = "mor";
+    msg.status.location.exit_city_name =
+      "Actually no idea what the name would be";
+
+    const result = fromVPNStatusResponse(msg, list);
+    expect(result.exitServerCity).toBe(list[1][0]);
+    expect(result.exitServerCountry).toBe(list[1]);
+    expect(result.connected).toBe(false);
+    expect(result.state).toBe("Disabled");
+  });
+  it("It creates a StatOn Status ", () => {
+    const msg = new vpnStatusResponse();
+    msg.status.vpn = "StateOn";
+    msg.status.connectedSince = "1";
+    msg.status.location.entry_city_name = "berlin";
+    msg.status.location.entry_country_code = "de";
+    msg.status.location.exit_country_code = "mor";
+    msg.status.location.exit_city_name =
+      "Actually no idea what the name would be";
+
+    const result = fromVPNStatusResponse(msg, list);
+    expect(result.exitServerCity).toBe(list[1][0]);
+    expect(result.exitServerCountry).toBe(list[1]);
+    expect(result.connected).toBe(true);
+    expect(result.connectedSince).toBe(1);
+    expect(result.state).toBe("Enabled");
+  });
+  it("It can handle omition of connectedSince ", () => {
+    const msg = new vpnStatusResponse();
+    msg.status.vpn = "StateOn";
+    delete msg.status.connectedSince;
+    msg.status.location.entry_city_name = "berlin";
+    msg.status.location.entry_country_code = "de";
+    msg.status.location.exit_country_code = "mor";
+    msg.status.location.exit_city_name =
+      "Actually no idea what the name would be";
+
+    const result = fromVPNStatusResponse(msg, list);
+    expect(result.exitServerCity).toBe(list[1][0]);
+    expect(result.exitServerCountry).toBe(list[1]);
+    expect(result.connected).toBe(true);
+    expect(result.connectedSince).toBe(0);
+    expect(result.state).toBe("Enabled");
+  });
+});


### PR DESCRIPTION
So the idea is to remove the `VPNState(oldstate)` pattern. 
I originally chose this pattern as we only had one message-pipe thing and it would have been mindbogglingly annyoing to write `getServers` `getInfoX` etc commands. So if we only had an immutable sum type for the state i could avoid some complexity :) 
This however meant that we were creating a new immutable copy of the serverlist even if just the connection status changed. 


Given we now have property's and ipc none of those reasons exists, i can now easily have multiple fields that push info as they come in. 
So i think it's nicer to have `postToApp(servers) -> will update VPNController.servers-> will notify property subscribers`. 

