### PR TITLE
Add npm run start-dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "addonslinter": "addons-linter --privileged src/",
     "typecheck": "tsc --noEmit",
     "build": "web-ext build --source-dir src --filename mozilla-vpn-extension.xpi",
-    "start": "web-ext run --verbose --source-dir src --pref=ui.popup.disable_autohide=true ",
+    "start-dev": "web-ext run --verbose --source-dir src --pref=ui.popup.disable_autohide=true",
+    "start": "web-ext run --verbose --source-dir src",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --collect-coverage --detectOpenHandles"
   },
   "repository": {


### PR DESCRIPTION
This PR adds "npm run start-dev" where we disable autohiding of popups in the hopes of stemming the tide of "would never happen in the wild bugs" like https://mozilla-hub.atlassian.net/browse/FXVPN-159. 