### PR TITLE
IconButton: Move click handler to button instead of image

### DIFF
--- a/src/components/iconbutton.js
+++ b/src/components/iconbutton.js
@@ -43,15 +43,14 @@ export class IconLinkButton extends LitElement {
   }
   render() {
     return html`
-      <button title="${this.alt}"
-      @click=${() => {
-        this.onClick();
-      }}
-      class="ghost-btn ghost-icon-btn">
-        <img
-          aria-hidden="true"
-          src="../../assets/img/${this.icon}.svg"
-        />
+      <button
+        title="${this.alt}"
+        @click=${() => {
+          this.onClick();
+        }}
+        class="ghost-btn ghost-icon-btn"
+      >
+        <img aria-hidden="true" src="../../assets/img/${this.icon}.svg" />
       </button>
     `;
   }

--- a/src/components/iconbutton.js
+++ b/src/components/iconbutton.js
@@ -43,12 +43,13 @@ export class IconLinkButton extends LitElement {
   }
   render() {
     return html`
-      <button title="${this.alt}" class="ghost-btn ghost-icon-btn">
+      <button title="${this.alt}"
+      @click=${() => {
+        this.onClick();
+      }}
+      class="ghost-btn ghost-icon-btn">
         <img
           aria-hidden="true"
-          @click=${() => {
-            this.onClick();
-          }}
           src="../../assets/img/${this.icon}.svg"
         />
       </button>
@@ -57,6 +58,10 @@ export class IconLinkButton extends LitElement {
 
   static styles = css`
     ${ghostButtonStyles}
+
+    img {
+      pointer-events: none;
+    }
   `;
 }
 customElements.define("mz-iconlink", IconLinkButton);


### PR DESCRIPTION
This moves the clickHandler for iconbutons to the <button> elem instead of the nested <img> so that the entire button area is clickable, instead of just the nested image height/width.