### PR TITLE
Update in-use label and location picker behavior 

### DIFF
--- a/src/components/styles.js
+++ b/src/components/styles.js
@@ -158,3 +158,20 @@ export const ghostButtonStyles = css`
     }
   }
 `;
+
+export const inUseLabel = css`
+  .in-use {
+    font-size: 11px;
+    font-weight: bold;
+    margin: 0px 10px;
+    padding: 6px 10px;
+    background: var(--main-card--pill-background);
+    opacity: 0.9;
+    border-radius: 6px;
+    line-height: inherit;
+  }
+
+  .in-use-light {
+    background-color: #e7e7e7;
+  }
+`;

--- a/src/components/vpncard.js
+++ b/src/components/vpncard.js
@@ -25,6 +25,7 @@ export class VPNCard extends LitElement {
     cityName: { type: String },
     countryFlag: { type: String },
     stability: { type: String },
+    hasContext: { type: Boolean },
   };
 
   constructor() {
@@ -113,11 +114,10 @@ export class VPNCard extends LitElement {
       <footer>
         <img
           src="../../assets/flags/${countryFlag}.png"
-          width="24"
-          height="24"
+          width="16"
+          height="16"
         />
         <p>${name}</p>
-        <span> In Use </span>
       </footer>
     `;
   }
@@ -186,7 +186,7 @@ export class VPNCard extends LitElement {
       justify-content: baseline;
     }
     footer img {
-      margin-right: 8px;
+      margin-right: 12px;
     }
     main {
       justify-content: space-between;
@@ -197,15 +197,12 @@ export class VPNCard extends LitElement {
       justify-content: flex-start;
       width: 100%;
       border-top: 1px solid var(--border-color);
-      padding: 10px var(--default-padding);
+      padding: 0px var(--default-padding);
+      height: 40px;
     }
     footer p {
       color: var(--text-color-primary);
       font-size: 14px;
-    }
-    footer span {
-      font-size: 11px;
-      font-weight: bold;
     }
 
     .box * {
@@ -290,15 +287,6 @@ export class VPNCard extends LitElement {
     .on .pill::before {
       top: 3px;
       left: 24px;
-    }
-
-    span {
-      margin: 0px 10px;
-      color: var(--text-color-primary);
-      padding: 6px 10px;
-      background: var(--main-card--pill-background);
-      opacity: 0.9;
-      border-radius: 6px;
     }
   `;
 }

--- a/src/ui/browserAction/popupPage.js
+++ b/src/ui/browserAction/popupPage.js
@@ -441,7 +441,7 @@ export class BrowserActionPopup extends LitElement {
     }
 
     #selectPageLocation:disabled,
-    #reset-context.disabled {
+    #selectLocation.disabled {
       opacity: 0.5;
       pointer-events: none;
     }

--- a/src/ui/browserAction/popupPage.js
+++ b/src/ui/browserAction/popupPage.js
@@ -277,9 +277,9 @@ export class BrowserActionPopup extends LitElement {
             width="16"
           />
           <p>${getNameForContext(siteContext)}</p>
-          ${hasSiteContext && !siteContext.excluded ?
-          html`<span class="in-use in-use-light"> In Use </span>` : null
-          }
+          ${hasSiteContext && !siteContext.excluded
+            ? html`<span class="in-use in-use-light"> In Use </span>`
+            : null}
           <img
             src="../../assets/img/arrow-icon-right.svg"
             height="12"
@@ -370,7 +370,7 @@ export class BrowserActionPopup extends LitElement {
     .row img:first-child {
       margin: auto 12px auto 0px;
     }
-    
+
     .in-use {
       margin: auto auto auto 8px;
     }
@@ -385,7 +385,7 @@ export class BrowserActionPopup extends LitElement {
       margin-block: 0px;
       display: flex;
       height: 40;
-      justify-content: flex-start
+      justify-content: flex-start;
     }
 
     #selectPageLocation:hover {

--- a/src/ui/browserAction/popupPage.js
+++ b/src/ui/browserAction/popupPage.js
@@ -272,7 +272,7 @@ export class BrowserActionPopup extends LitElement {
           @click=${openServerList}
         >
           <img
-            src="../../assets//flags/${siteContext.countryCode.toUpperCase()}.png"
+            src="../../assets/flags/${siteContext.countryCode.toUpperCase()}.png"
             height="16"
             width="16"
           />

--- a/src/ui/browserAction/popupPage.js
+++ b/src/ui/browserAction/popupPage.js
@@ -20,6 +20,7 @@ import {
   fontSizing,
   ghostButtonStyles,
   resetSizing,
+  inUseLabel,
 } from "../../components/styles.js";
 
 // Other components used
@@ -152,6 +153,7 @@ export class BrowserActionPopup extends LitElement {
               .countryFlag=${this.vpnState?.exitServerCountry?.code}
               .connectedSince=${this.vpnState?.connectedSince}
               .stability=${this.vpnState?.connectionStability}
+              .hasContext=${this._siteContext}
             ></vpn-card>
             ${this.locationSettings()}
           </main>
@@ -266,14 +268,18 @@ export class BrowserActionPopup extends LitElement {
         <button
           class="row ghost-btn "
           id="selectPageLocation"
+          .disabled=${live(siteContext.excluded)}
           @click=${openServerList}
         >
           <img
             src="../../assets//flags/${siteContext.countryCode}.png"
-            height="24"
-            width="24"
+            height="16"
+            width="16"
           />
           <p>${getNameForContext(siteContext)}</p>
+          ${hasSiteContext && !siteContext.excluded ?
+          html`<span class="in-use in-use-light"> In Use </span>` : null
+          }
           <img
             src="../../assets/img/arrow-icon-right.svg"
             height="12"
@@ -304,12 +310,7 @@ export class BrowserActionPopup extends LitElement {
       </button>
     `;
   }
-  static styles = css`
-    #reset-context.disabled {
-      opacity: 0.7;
-      pointer-events: none;
-    }
-  `;
+
   static backBtn(back) {
     return html` <mz-iconlink
       @goBack=${back}
@@ -345,7 +346,7 @@ export class BrowserActionPopup extends LitElement {
   }
 
   static styles = css`
-    ${fontSizing}${resetSizing}${ghostButtonStyles}
+    ${fontSizing}${resetSizing}${ghostButtonStyles}${inUseLabel}
     section {
       background-color: var(--panel-bg-color);
     }
@@ -366,23 +367,25 @@ export class BrowserActionPopup extends LitElement {
       align-items: center;
     }
 
-    .row p {
-      flex: 1;
-      flex-grow: 1;
-    }
-
     .row img:first-child {
-      margin-right: var(--padding-default);
+      margin: auto 12px auto 0px;
+    }
+    
+    .in-use {
+      margin: auto auto auto 8px;
     }
 
     .row img:last-of-type {
-      margin-left: var(--padding-default);
+      margin: auto 0 auto auto;
     }
 
     #selectPageLocation {
-      padding: calc(var(--padding-default) / 2) 0px;
+      padding: 0;
       position: relative;
       margin-block: 0px;
+      display: flex;
+      height: 40;
+      justify-content: flex-start
     }
 
     #selectPageLocation:hover {
@@ -437,10 +440,10 @@ export class BrowserActionPopup extends LitElement {
       margin-block: var(--padding-default);
     }
 
-    .disabled {
-      cursor: not-allowed;
-      pointer-events: none;
+    #selectPageLocation:disabled,
+    #reset-context.disabled {
       opacity: 0.5;
+      pointer-events: none;
     }
 
     @media (prefers-color-scheme: dark) {

--- a/src/ui/variables.css
+++ b/src/ui/variables.css
@@ -32,7 +32,7 @@
 
 :root {
   --window-width: 352px;
-  --window-max-height: 474px;
+  --window-max-height: 468px;
 
   --font-family: "Inter Regular";
   --font-family-semi-bold: "Inter Semi Bold";


### PR DESCRIPTION
Here we:
- Remove the "in-use" label from vpn-card (FXVPN-169)
- Add an "in-use" label to the location picker button that is 
  - visible when a site-specific location setting is not in effect 
  - hidden when the site is excluded
  - disable the location picker button when the site is excluded (FXVPN-167)
- Makes some opportunistic UI tweaks   
<img width="361" alt="Screenshot 2024-09-25 at 12 39 21 PM" src="https://github.com/user-attachments/assets/a595e966-324e-4ee1-9098-646d38248b8c">
<img width="353" alt="Screenshot 2024-09-25 at 12 39 29 PM" src="https://github.com/user-attachments/assets/8e2e7328-3c2b-404b-b8d3-79d487c29473">
