### PR TITLE
Clean up English localization file

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -33,15 +33,15 @@
   },
   "titleServerList": {
     "message": "Select site location",
-    "description": "The header of a Serverlist, prompting the user to select a location"
+    "description": "The header of a list of servers, prompting the user to select a location"
   },
   "titlePageSettings": {
     "message": "Preferences for this site",
-    "description": "The header for website specific settings i.e exclude a page from vpn"
+    "description": "The header for website specific settings, i.e. exclude a page from VPN"
   },
-  "exludePageFor": {
-    "message": "Always turn off VPN protection for  $origin$ ",
-    "description": "Setting to exclude a website from vpn ",
+  "excludePageFor": {
+    "message": "Always turn off VPN protection for $ORIGIN$",
+    "description": "Setting to exclude a website from VPN",
     "placeholders": {
       "origin": {
         "content": "$1",
@@ -51,7 +51,7 @@
   },
   "resetPageSettings": {
     "message": "Reset site preferences",
-    "description": "Button Text to Reset all Site specific settings"
+    "description": "Button text to reset all site specific settings"
   },
   "vpnIsOn": {
     "message": "VPN protection for Firefox is on",
@@ -94,15 +94,15 @@
     "description": "Table heading for the column showing the location of the website."
   },
   "headlineNoWebsitePreferences": {
-    "message": "You haven't set any website preferences yet",
-    "description": "Headline shown when the user hasn't set any website preferences."
+    "message": "You haven’t set any website preferences yet",
+    "description": "Headline shown when the user hasn’t set any website preferences."
   },
   "noWebsitePreferencesSubText": {
-    "message": "If you turn off VPN protection or set a custom location for any websites, you'll see them here.",
+    "message": "If you turn off VPN protection or set a custom location for any websites, you’ll see them here.",
     "description": "Subtext shown when there are no website preferences set by the user."
   },
   "altTextRemoveWebsiteButton": {
-    "message": "Remove rule for $origin$",
+    "message": "Remove rule for $ORIGIN$",
     "description": "Alt text for the button that removes a website rule from the list of preferences.",
     "placeholders": {
       "origin": {
@@ -117,18 +117,18 @@
   },
   "searchServer": {
     "message": "Search location",
-    "description": "Placeholder for the Input field Where users can search the Serverlist"
+    "description": "Placeholder for the Input field where users can search the list of servers"
   },
   "titleSubscribeNow": {
     "message": "Subscribe to Mozilla VPN"
   },
   "bodySubscribeNow": {
     "message": "No subscription found. Click the button below to subscribe to Mozilla VPN.",
-    "description": "Body of an Error Message, shown if the user is trying to use the Extension without a Subscription."
+    "description": "Body of an error message, shown if the user is trying to use the extension without a subscription."
   },
   "btnSubscribeNow": {
     "message": "Subscribe now",
-    "description": "Call to Action button for users to subscribe to Mozilla VPN"
+    "description": "Call to action button for users to subscribe to Mozilla VPN"
   },
   "getHelp": {
     "message": "Get Help",
@@ -152,19 +152,18 @@
   },
   "bodyInstallMsgFooter": {
     "message": "Note that Mozilla VPN is a paid subscription service.",
-    "description": "This is a footnote for 'bodyInstallMsg' "
+    "description": "This is a footnote for “bodyInstallMsg”"
   },
   "btnDownloadNow": {
     "message": "Download now",
     "description": "This is a call to action button to download the VPN."
   },
   "defaultLocationHeader": {
-    "message": "Use default Mozilla VPN location",
-    "description": "Header for useDefaultLocationExplainer"
+    "message": "Use default Mozilla VPN location"
   },
   "useDefaultLocationExplainer": {
     "message": "This is always the same location as selected in your Mozilla VPN desktop app.",
-    "description": "Explanation of what 'Use default Mozilla VPN Location' means."
+    "description": "Explanation of what “Use default Mozilla VPN Location” means."
   },
   "headerUnsupportedOSMessage": {
     "message": "Unsupported platform"

--- a/src/ui/browserAction/popupPage.js
+++ b/src/ui/browserAction/popupPage.js
@@ -209,7 +209,7 @@ export class BrowserActionPopup extends LitElement {
 
     const getExclusionStringElem = (origin) => {
       const originPlaceholder = "dummyString";
-      const localizedString = tr("exludePageFor", originPlaceholder);
+      const localizedString = tr("excludePageFor", originPlaceholder);
       // Create a new <p> element
       const el = document.createElement("p");
 


### PR DESCRIPTION
Mostly apostrophes, but also improving comments.

I assume the extra spaces in `exludePageFor` (fixed typo too) are not wanted?