### PR TITLE
No ticket: fix tiny alignment issue

### DIFF
--- a/src/components/styles.js
+++ b/src/components/styles.js
@@ -179,6 +179,7 @@ export const positioner = css`
     align-items: center;
     justify-content: center;
     margin-inline-end: 8px;
+    flex: 0 0 auto;
   }
 `;
 

--- a/src/ui/browserAction/popupPage.js
+++ b/src/ui/browserAction/popupPage.js
@@ -399,7 +399,6 @@ export class BrowserActionPopup extends LitElement {
 
     .row {
       display: flex;
-      justify-content: center;
       align-items: center;
     }
 


### PR DESCRIPTION
Fixes the tiniest alignment issue in the main panel.
<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="250" src="https://github.com/user-attachments/assets/5d979d06-8455-4dab-975c-acb0cad7f2b2">
</td>
<td>


<img src="https://github.com/user-attachments/assets/f2e9f8ad-59d7-4545-8444-7f4992a0ca66" width="250">
</td>
</tr>


</table>

