### PR TITLE
Implement Linux support via UNIX socket proxy

### DIFF
--- a/src/background/proxyHandler/proxyHandler.js
+++ b/src/background/proxyHandler/proxyHandler.js
@@ -34,7 +34,9 @@ export class ProxyHandler extends Component {
   constructor(receiver, controller) {
     super(receiver);
     this.controller = controller;
-    browser.runtime.getPlatformInfo(info => { this.#mPlatformOs = info.os});
+    browser.runtime.getPlatformInfo((info) => {
+      this.#mPlatformOs = info.os;
+    });
   }
 
   /** @type {VPNState | undefined} */
@@ -111,13 +113,15 @@ export class ProxyHandler extends Component {
   processClientStateChanges(vpnState) {
     console.log(`Processing client state change ${vpnState}`);
     if (this.#mPlatformOs === "linux") {
-      this.#mLocalProxyInfo.value = [{
-        type: "socks",
-        host: "file:/var/run/mozillavpn.proxy",
-        port: 1234,
-      }]
+      this.#mLocalProxyInfo.value = [
+        {
+          type: "socks",
+          host: "file:/var/run/mozillavpn.proxy",
+          port: 1234,
+        },
+      ];
     } else if (vpnState.loophole) {
-      this.#mLocalProxyInfo.value = [ProxyUtils.parseProxy(vpnState.loophole)]
+      this.#mLocalProxyInfo.value = [ProxyUtils.parseProxy(vpnState.loophole)];
     } else {
       this.#mLocalProxyInfo.value = [];
     }


### PR DESCRIPTION
This is a companion PR to mozilla-mobile/mozilla-vpn-client#9952 that implements Linux support by connecting to the SOCKS proxy as a systemd service. Basically all we do here is check if the platform is `linux` and set the bypass proxy to `{type: "socks", host: "file:/var/run/mozillavpn.proxy", port: 1234}` The port number here isn't used, but it seems to be required in order to be parsed as a valid proxy.

Update! Now it supports connecting to the Windows proxy service too. Similar logic, we just check the platform and generate a fixed proxy config.