### PR TITLE
Remove 'Open Mozilla VPN' button from error message

### DIFF
--- a/src/components/prefab-screens.js
+++ b/src/components/prefab-screens.js
@@ -69,11 +69,6 @@ defineMessageScreen(
   "message-signin.svg",
   tr("headerSignedOut"),
   tr("bodySignedOut"),
-  tr("btnOpenVpn"),
-  (elm) => {
-    sendToApp(elm, "focus");
-    sendToApp(elm, "openAuth");
-  }
 );
 
 defineMessageScreen(

--- a/src/components/prefab-screens.js
+++ b/src/components/prefab-screens.js
@@ -68,7 +68,7 @@ defineMessageScreen(
   "signin-message-screen",
   "message-signin.svg",
   tr("headerSignedOut"),
-  tr("bodySignedOut"),
+  tr("bodySignedOut")
 );
 
 defineMessageScreen(


### PR DESCRIPTION
This PR removes the 'Open Mozilla VPN' button from the sign-in needed error panel. There is no dedicated ticket for this but see [this Jira comment ](https://mozilla-hub.atlassian.net/browse/FXVPN-193?focusedCommentId=956275)for the decision to remove it.