### PR TITLE
Fix content alignment in error panels

### DIFF
--- a/src/components/message-screen.js
+++ b/src/components/message-screen.js
@@ -104,6 +104,7 @@ export class MessageScreen extends LitElement {
       justify-content: space-between;
       /* ensure the content grows vertically to fill the height of the panel */
       min-block-size: calc(var(--min-block-size) - var(--nav-height));
+      margin-inline: auto;
     }
     * {
       width: 100%;


### PR DESCRIPTION
<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="359" alt="Screenshot 2024-11-08 at 2 33 04 PM" src="https://github.com/user-attachments/assets/dca94568-2924-42b2-82dd-b6c63f9776fd">
</td>
<td>
<img width="362" alt="Screenshot 2024-11-08 at 2 33 32 PM" src="https://github.com/user-attachments/assets/a8a34cb5-9eac-480a-97be-0dad17423a13">
</td>
</tr>
</table>