### PR TITLE
Unhide error copy

### DIFF
--- a/src/ui/browserAction/popup.css
+++ b/src/ui/browserAction/popup.css
@@ -22,7 +22,3 @@ body {
   max-height: calc(var(--window-max-height) - var(--nav-height));
   max-block-size: calc(var(--window-max-height)- var(--nav-height));
 }
-
-.needsSlotted * {
-  display: none;
-}

--- a/src/ui/browserAction/popup.css
+++ b/src/ui/browserAction/popup.css
@@ -22,3 +22,7 @@ body {
   max-height: calc(var(--window-max-height) - var(--nav-height));
   max-block-size: calc(var(--window-max-height)- var(--nav-height));
 }
+
+.needsSlotted > * {
+  display: none;
+}


### PR DESCRIPTION
Fixes visibility of error message body copy. 
<table>
<tr>
<th>before</th>
<th>after</th>
</tr>
<tr>
<td>
<img width="400" alt="Screenshot 2024-11-25 at 10 25 54 AM" src="https://github.com/user-attachments/assets/78898002-6b47-4e21-9c79-ba0d176ad8bf">

</td>
<td>

<img width="400" alt="Screenshot 2024-11-25 at 10 26 03 AM" src="https://github.com/user-attachments/assets/849f9cd1-7700-482b-99f5-c7c6357e602e">

</td>
</tr>

</table>