### PR TITLE
Allow disconnect from connecting state

### DIFF
--- a/src/background/extensionController/extensionController.js
+++ b/src/background/extensionController/extensionController.js
@@ -27,6 +27,7 @@ export class ExtensionController extends Component {
   static properties = {
     state: PropertyType.Bindable,
     toggleConnectivity: PropertyType.Function,
+    allowDisconnect: PropertyType.Bindable
   };
 
   /**
@@ -51,6 +52,11 @@ export class ExtensionController extends Component {
   async init() {}
 
   toggleConnectivity() {
+    if (this.#mState.value.state === "Connecting" && this.clientState.state === "Disabled") {
+        this.#mState.set(new StateFirefoxVPNDisabled(true));
+        this.vpnController.postToApp("deactivate");
+        return;
+    }
     if (this.#mState.value.enabled) {
       // We are turning off the extension
 
@@ -73,12 +79,22 @@ export class ExtensionController extends Component {
     }
 
     this.#mState.set(new StateFirefoxVPNConnecting());
+
+    this.#mAllowDisconnect.value = false;
+    setTimeout(() => {
+      this.#mAllowDisconnect.value = true;
+    }, 10000);
+
     // Send activation to client and wait for response
     this.vpnController.postToApp("activate");
   }
 
   get state() {
     return this.#mState.readOnly;
+  }
+
+  get allowDisconnect() {
+    return this.#mAllowDisconnect.readOnly;
   }
 
   /**
@@ -137,5 +153,6 @@ export class ExtensionController extends Component {
   }
 
   #mState = property(new FirefoxVPNState());
+  #mAllowDisconnect = property(false)
   mKeepAliveConnection = false;
 }

--- a/src/components/vpncard.js
+++ b/src/components/vpncard.js
@@ -28,6 +28,7 @@ export class VPNCard extends LitElement {
     stability: { type: String },
     hasContext: { type: Boolean },
     connecting: { type: Boolean },
+    allowDisconnect: { type: Boolean }
   };
 
   constructor() {
@@ -39,6 +40,7 @@ export class VPNCard extends LitElement {
     this.connectedSince = 0;
     this.stability = VPNState.Stable;
     this.connecting = false;
+    this.allowDisconnect = false;
   }
   #intervalHandle = null;
 
@@ -64,6 +66,7 @@ export class VPNCard extends LitElement {
       box: true,
       on: this.enabled,
       connecting: this.connecting,
+      allowDisconnect: this.allowDisconnect,
       unstable: this.enabled && this.stability === VPNState.Unstable,
       noSignal: this.enabled && this.stability === VPNState.NoSignal,
       stable:
@@ -201,6 +204,15 @@ export class VPNCard extends LitElement {
     .box.connecting {
       background: var(--main-card-background);
       box-shadow: var(--box-shadow-on);
+    }
+
+    .box.connecting .pill {
+      pointer-events: none;
+    }
+
+    .box.connecting.allowDisconnect .pill {
+      pointer-events: all;
+      opacity: 1;
     }
     main,
     footer {

--- a/src/ui/browserAction/popupPage.js
+++ b/src/ui/browserAction/popupPage.js
@@ -57,6 +57,7 @@ export class BrowserActionPopup extends LitElement {
     _siteContext: { type: Object },
     hasSiteContext: { type: Boolean },
     _siteContexts: { type: Array },
+    allowDisconnect: { type: Boolean }
   };
 
   constructor() {
@@ -78,6 +79,9 @@ export class BrowserActionPopup extends LitElement {
       this.updatePage();
     });
     this.updatePage();
+    extController.allowDisconnect.subscribe((s) => {
+      this.allowDisconnect = s;
+    });
   }
   updatePage() {
     Utils.getCurrentTab().then(async (tab) => {
@@ -180,6 +184,7 @@ export class BrowserActionPopup extends LitElement {
               .stability=${this.vpnState?.connectionHealth}
               .hasContext=${this._siteContext}
               .connecting=${this.extState?.connecting}
+              .allowDisconnect=${this.allowDisconnect}
             ></vpn-card>
             ${this.locationSettings()}
           </main>


### PR DESCRIPTION
This PR was originally intended to fix FXVPN-266, but apparently the regression described in FXVPN-266 only happens on Mac and is therefore not a priority for us now. In the course of working on this on Mac I realized that, if a user gets stuck in a 'connecting' state becuase the client never successfully moves to 'StateOnPartial', the user has no way to deactivate the connection since the client UI does not provide this. 
This PR adds a 15 second timeout to the connecting state, after which the VPN toggle becomes enabled again and the user can terminate the connection attempt. 