### PR TITLE
Fix 'needs update' error message visibility

### DIFF
--- a/src/ui/browserAction/popupConditional.js
+++ b/src/ui/browserAction/popupConditional.js
@@ -45,6 +45,9 @@ export class PopUpConditionalView extends ConditionalView {
     if (!state.installed) {
       return "MessageInstallVPN";
     }
+    if (state.needsUpdate) {
+      return "MessageUpdateClient";
+    }
     if (!state.alive) {
       return "MessageOpenMozillaVPN";
     }
@@ -56,9 +59,6 @@ export class PopUpConditionalView extends ConditionalView {
     }
     if (!state.subscribed) {
       return "MessageSubscription";
-    }
-    if (state.needsUpdate) {
-      return "MessageUpdateClient";
     }
     /**
      * TODO:


### PR DESCRIPTION
In FXVPN-60, QA commented that when using the extension with older versions of the client they see the `MessageSignIn` screen instead of the `MessageUpdateClient` screen. Outdated clients, depending on the version, can meet the criteria for multiple error messages so this PR reorders the conditional block in popupConditional.js so that  `needsUpdate` is just after the installation check.

<table>
<tr>
<th>
v2.20
</th>
<th>
v2.21
</th>
<th>
v2.22
</th>
<th>
v2.26
</th>
</tr>
<tr>
<td>

![ss_2 20](https://github.com/user-attachments/assets/858ca97e-fffd-4299-8901-2c43c93d0da1)
</td>
<td>

![Screenshot 2024-11-26 141800](https://github.com/user-attachments/assets/5a11cb0e-09a7-42dc-be53-31341b112cff)

</td>
<td>

![ss_v2 22](https://github.com/user-attachments/assets/2f84e91d-81b4-4441-b9f7-cdcbe04aa714)
</td>
<td>

![Screenshot 2024-11-26 143309](https://github.com/user-attachments/assets/104fd408-9e7f-4924-8c45-ca82cd18b605)
</td>
</tr>
</table>


Note that pre v2.20 clients and earlier do not include the mozilla vpn extension in their manifest so we have no way of communicating with them.
