### PR TITLE
FXVPN-293: Improve Unsupported Platform message visibility

### DIFF
--- a/src/background/vpncontroller/vpncontroller.js
+++ b/src/background/vpncontroller/vpncontroller.js
@@ -368,5 +368,5 @@ export function fromVPNStatusResponse(
 
 export class FeatureFlags {
   localProxy = true;
-  webExtension = true;
+  webExtension = false;
 }

--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -19,6 +19,10 @@ export const Utils = {
     return currentTab[0];
   },
 
+  isSupportedOs(os) {
+    return ["win"].includes(os);
+  },
+
   isViableClientVersion: (clientVersion) => {
     // TODO we should do something better here
     // We'll likely want to update the minimumViableClient

--- a/src/ui/browserAction/popupConditional.js
+++ b/src/ui/browserAction/popupConditional.js
@@ -21,7 +21,11 @@ export class PopUpConditionalView extends ConditionalView {
       vpnController.state,
       vpnController.featureList,
       (state, features) => {
-        this.slotName = PopUpConditionalView.toSlotname(state, features, supportedPlatform);
+        this.slotName = PopUpConditionalView.toSlotname(
+          state,
+          features,
+          supportedPlatform
+        );
       }
     );
 
@@ -43,12 +47,12 @@ export class PopUpConditionalView extends ConditionalView {
    * @typedef {import("../../background/vpncontroller/states.js").VPNState} State
    * @param {State} state
    * @param {FeatureFlags} features
-   * @param {Boolean} supportedPlatform 
+   * @param {Boolean} supportedPlatform
    * @returns {String}
    */
   static toSlotname(state, features, supportedPlatform) {
     if (!supportedPlatform && !features.webExtension) {
-      return "MessageOSNotSupported"
+      return "MessageOSNotSupported";
     }
     if (!state.installed) {
       return "MessageInstallVPN";

--- a/src/ui/browserAction/popupPage.js
+++ b/src/ui/browserAction/popupPage.js
@@ -115,6 +115,9 @@ export class BrowserActionPopup extends LitElement {
     requestIdleCallback(() => {
       vpnController.postToApp("servers");
     });
+    requestIdleCallback(() => {
+      vpnController.postToApp("featurelist");
+    });
   }
 
   get currentSiteContext() {


### PR DESCRIPTION
This PR: 
- Sets the `webExtension` flag to false by default. 
  - This prevents folks on unsupported platforms with older versions of the client (which predate the `webExtension` flag) from being shown the the "Update now" panel instead of the "Unsupported Platform" panel. Tested this with a v2.24.2 on mac.
- Identifies the OS with `await browser.runtime.getPlatformInfo()` and uses this to conditionally show the unsupported platform panel.
  - Preserves the ability for people on unsupported platforms to use the extension by enabling the `webExtension` flag.
- Requests the `featurelist` when the popup is opened to catch changes to the `webExtension` flag

A side-effect of this PR is that Windows users who flag off `webExtension` flag will not see any changes in the extension. Given the localproxy will now run on Windows without a flag I think this is acceptable. 

