### PR TITLE
FXVPN-264 - Update the timer on first update

### DIFF
--- a/src/components/vpncard.js
+++ b/src/components/vpncard.js
@@ -43,10 +43,22 @@ export class VPNCard extends LitElement {
   #intervalHandle = null;
 
   updated(changedProperties) {
+    super.updated(changedProperties);
     if (!changedProperties.has("enabled")) {
       return;
     }
-    if (this.enabled) {
+    this.#setTimer(this.enabled);
+  }
+  firstUpdated() {
+    super.firstUpdated();
+    this.#setTimer(this.enabled);
+  }
+
+  #setTimer(enable) {
+    if (enable) {
+      if (this.#intervalHandle != null) {
+        return;
+      }
       this.#intervalHandle = setInterval(() => {
         this.requestUpdate();
       }, 1000);


### PR DESCRIPTION
We currenlty only enable the timer if the "enabled" property changes. 
However if the element was created with `enabled=true` that will not change it, therefore we never update it. 
Let's double check also in `firstUpdate`, which is just after the first render to html.