### PR TITLE
FXVPN-12 - Allow Extension to set Client Telemetry Setting

### DIFF
--- a/src/background/vpncontroller/states.js
+++ b/src/background/vpncontroller/states.js
@@ -20,6 +20,7 @@ export const REQUEST_TYPES = [
   "session_start",
   "session_stop",
   "interventions",
+  "settings",
 ];
 
 export class VPNState {
@@ -213,4 +214,8 @@ export class vpnStatusResponse {
     },
     version: "2.25.0",
   };
+}
+
+export class VPNSettings {
+  extensionTelemetryEnabled = false;
 }


### PR DESCRIPTION
Companion PR: https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10112/files

This PR adds the VPNController functions to reflect and modify certain VPN Client settings. 