### PR TITLE
Switch to localstorage

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "lint": "concurrently npm:prettier npm:typecheck",
     "format": "prettier . --write",
+    "format-file": "prettier --write --",
     "prettier": "prettier . --check",
     "addonslinter": "addons-linter --privileged src/",
     "typecheck": "tsc --noEmit",

--- a/src/background/proxyHandler/proxyUtils.js
+++ b/src/background/proxyHandler/proxyUtils.js
@@ -10,9 +10,7 @@ export const ProxyUtils = {
    * @readonly
    * @type {string}
    */
-  getSiteContextsStorageKey() {
-    return "siteContexts";
-  },
+  SiteContextsStorageKey: "siteContexts",
 
   getDirectProxyInfoObject() {
     return { type: "direct" };

--- a/tests/jest/background/proxyHandler/proxyUtils.test.mjs
+++ b/tests/jest/background/proxyHandler/proxyUtils.test.mjs
@@ -7,7 +7,7 @@ import { ProxyUtils } from "../../../../src/background/proxyHandler/proxyUtils";
 
 describe("ProxyUtils", () => {
   describe("getSiteContextsStorageKey", () => {
-    const result = ProxyUtils.getSiteContextsStorageKey();
+    const result = ProxyUtils.SiteContextsStorageKey;
     expect(result).toBe("siteContexts");
     /* 
       If you've failed this test it is because you've changed the value of


### PR DESCRIPTION
Ugh - it seems somehow we only get an `{}` in the browser.sync.onchanged. 
I'm not quite sure what is causing this. 