### PR TITLE
Allow propertySum to consume any amount of properties

### DIFF
--- a/src/background/requestHandler.js
+++ b/src/background/requestHandler.js
@@ -42,11 +42,11 @@ export class RequestHandler extends Component {
     });
 
     propertySum(
-      proxyHandler.localProxyInfo,
-      proxyHandler.currentExitRelays,
       (loophole, exitRelays) => {
         this.updateProxyInfoFromClient(loophole, exitRelays);
-      }
+      },
+      proxyHandler.localProxyInfo,
+      proxyHandler.currentExitRelays
     );
 
     proxyHandler.proxyMap.subscribe((proxyMap) => {

--- a/src/shared/property.js
+++ b/src/shared/property.js
@@ -181,7 +181,6 @@ export const propertySum = (transform, ...parent) => {
   };
   const inner = new WritableProperty(transform(...getValues()));
   const onUpdated = () => {
-    const values = getValues();
     inner.set(transform(...getValues()));
   };
   parent.forEach((p) => {

--- a/src/shared/property.js
+++ b/src/shared/property.js
@@ -31,34 +31,6 @@ export class IBindable {
   }
 }
 
-class BaseBindable extends IBindable {
-  /** @returns {T}  */
-  get value() {
-    return this.#innerValue;
-  }
-  /**
-   *
-   * @param {(T)=>void} callback - This callback will be called when the value changes
-   * @returns {()=>void} unsubscribe function, this will stop all callbacks
-   */
-  subscribe(callback) {
-    const unsubscribe = () => {
-      this.#subscriptions = this.#subscriptions.filter((t) => t !== callback);
-    };
-    this.#subscriptions.push(callback);
-    queueMicrotask(() => callback(this.#innerValue));
-    return unsubscribe;
-  }
-  /**
-   * @type {Array<(arg0: T)=>void> }
-   */
-  #subscriptions = [];
-  /**
-   * @type {T}
-   */
-  #innerValue;
-}
-
 /**
  * A property similar to Q_Property
  * Holds an internal value that can be modified using `.set(NewValue)`
@@ -68,7 +40,7 @@ class BaseBindable extends IBindable {
  *
  * @template T
  */
-export class WritableProperty extends BaseBindable {
+export class WritableProperty extends IBindable {
   /**
    * Constructs a Property<T> with an initial Value
    * @param {T} initialvalue

--- a/src/ui/browserAction/popupConditional.js
+++ b/src/ui/browserAction/popupConditional.js
@@ -18,15 +18,15 @@ export class PopUpConditionalView extends ConditionalView {
     const supportedPlatform = Utils.isSupportedOs(deviceOs.os);
 
     propertySum(
-      vpnController.state,
-      vpnController.featureList,
       (state, features) => {
         this.slotName = PopUpConditionalView.toSlotname(
           state,
           features,
           supportedPlatform
         );
-      }
+      },
+      vpnController.state,
+      vpnController.featureList
     );
 
     // Messages may dispatch an event requesting to send a Command to the VPN

--- a/tests/jest/utils/property.test.mjs
+++ b/tests/jest/utils/property.test.mjs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { describe, expect, test, jest } from "@jest/globals";
-import { property, computed } from "../../../src/shared/property";
+import { property, computed, propertySum } from "../../../src/shared/property";
 
 describe("property()", () => {
   test("Can create a property from a value", () => {
@@ -78,5 +78,52 @@ describe("computed()", () => {
     prop.set(2);
     expect(maybeValue).not.toBeNull();
     expect(maybeValue).toBe(4);
+  });
+});
+
+describe("propertySum", () => {
+  test("Can create a property from a value", () => {
+    const obj = property({ x: "hello" });
+    const prop = propertySum((obj) => {
+      return obj.x;
+    }, obj);
+    expect(prop.value.x).toBe(obj.x);
+  });
+  test("Calls the Transform Function in order of the props ", async () => {
+    const prop1 = property("hello");
+    const prop2 = property(4);
+    const prop3 = property(true);
+    propertySum(
+      (value1, value2, value3) => {
+        expect(value1).toBe(prop1.value);
+        expect(value2).toBe(prop2.value);
+        expect(value3).toBe(prop3.value);
+      },
+      prop1,
+      prop2,
+      prop3
+    );
+  });
+
+  test("If any of the props are updated, the transform is called", async () => {
+    const prop1 = property("hello");
+    const prop2 = property(4);
+    const prop3 = property(true);
+
+    let count = 0;
+    propertySum(
+      () => {
+        return count++;
+      },
+      prop1,
+      prop2,
+      prop3
+    );
+    // We auto scheudle the transform to compute the inital value
+    expect(count).toBe(1);
+    prop1.set("h");
+    prop2.set("h");
+    prop3.set("h");
+    expect(count).toBe(4);
   });
 });


### PR DESCRIPTION
- `computed` can be created without a type, so let's remove the class backing it. 
In #142 Matt hit a thing where a sum of more then 2 elements is required, let's refactor propertySum to work with N elements, and add tests for it :) 