### PR TITLE
FXVPN-304: Fix erroneous extension activations

### DIFF
--- a/src/background/extensionController/extensionController.js
+++ b/src/background/extensionController/extensionController.js
@@ -137,7 +137,6 @@ export class ExtensionController extends Component {
 
     switch (newClientState.state) {
       case "Enabled":
-        this.mKeepAliveConnection = true;
         maybeSet(new StateFirefoxVPNEnabled(false, getTime()));
         return;
       case "Disabled":
@@ -148,6 +147,7 @@ export class ExtensionController extends Component {
         this.#mState.set(new StateFirefoxVPNDisabled(false));
         return;
       case "OnPartial":
+        this.mKeepAliveConnection = true;
         maybeSet(new StateFirefoxVPNEnabled(true, getTime()));
         return;
       default:

--- a/src/background/extensionController/extensionController.js
+++ b/src/background/extensionController/extensionController.js
@@ -58,6 +58,7 @@ export class ExtensionController extends Component {
     ) {
       this.#mState.set(new StateFirefoxVPNDisabled(true));
       this.vpnController.postToApp("deactivate");
+      this.mKeepAliveConnection = false;
       return;
     }
     if (this.#mState.value.enabled) {

--- a/tests/jest/background/extensionController.js/extencontrollerTimer.test.mjs
+++ b/tests/jest/background/extensionController.js/extencontrollerTimer.test.mjs
@@ -139,7 +139,7 @@ describe("ExtensionController", () => {
       testController.state.set(new StateVPNEnabled());
       expect(target.state.value.enabled).toBe(true);
     });
-    test("If Firefox was launched when the VPN client was ON, turning the VPN client OFF, should NOT turn the VPN extension OFF.", () => {
+    test("If the client is unexpectedly deactivated from StateOnPartial, the extension should attempt to reactivate.", () => {
       const testController = new TestController(new StateVPNClosed());
 
       const target = new ExtensionController(
@@ -147,10 +147,10 @@ describe("ExtensionController", () => {
         testController
       );
       expect(target.state.value.enabled).toBe(false);
-      testController.state.set(new StateVPNEnabled());
+      testController.state.set(new StateVPNOnPartial());
       expect(target.state.value.enabled).toBe(true);
       // Given that the client did an unexpected disconnect,
-      // the extension should ask to re-enable instatnly
+      // the extension should ask to re-enable instantly
       // without disconnecting
       testController.state.set(new StateVPNDisabled());
       // We should have sent a reconnect


### PR DESCRIPTION
Slight tweak to the extension controller to change when we stipulate `mKeepAliveConnection = true` and when we call `activate` after a client deactivation.
The revised behavior is this:

1. Extension is activated while client is off ->(client is in StateOnPartial, extension is On, mkeepAliveConnection = true)
2. Client is later activated -> (now both extension and client are activated)
3. Client is deactivated -> (extension calls "activate" to reactivate the client into StateOnPartial)