### PR TITLE
improve height (follow up on FXVPN-10)

### DIFF
--- a/src/components/message-screen.js
+++ b/src/components/message-screen.js
@@ -55,12 +55,19 @@ export class MessageScreen extends LitElement {
         i + 1 === this.currentPage ? "circle active" : "circle"
       );
     }
+    const isOnboarding = (this.totalPages !== 0);
+    let imgString;
+    if (isOnboarding) {
+      imgString = html`<img class="${this.identifier}" src="/assets/img/${this.img}" height="145" />`
+    } else {
+      imgString = html`<img class="${this.identifier}" src="/assets/img/${this.img}"/>`
+    }
 
     return html`
       <vpn-titlebar title=${this.titleHeader}></vpn-titlebar>
       <div class="inner">
         <div class="upper">
-          <img class="${this.identifier}" src="/assets/img/${this.img}" />
+          ${imgString}
           <h1>${this.heading}</h1>
           <slot></slot>
         </div>


### PR DESCRIPTION
In FXVPN-10's QA, they noted that the second image is larger than expected. This fixes that. 

I couldn't get it working when keeping the img tag in the larger html block, and dynamically changing/inserting the height - happy to update this if we want to spend a second looking at this together.