### PR TITLE
Allow main popup panel to scroll

### DIFF
--- a/src/components/butter-bar.js
+++ b/src/components/butter-bar.js
@@ -74,11 +74,16 @@ export class ButterBar extends LitElement {
       box-sizing: border-box;
     }
 
+    .butter-bar-text p {
+      margin: 0;
+      line-height: 21px;
+    }
+
     .butter-bar-text {
       text-align: center;
       flex: 1;
       font-size: 13px;
-      padding: 8px 16px;
+      padding: 10px 16px;
       box-sizing: border-box;
       display: flex;
       justify-content: center;

--- a/src/components/vpncard.js
+++ b/src/components/vpncard.js
@@ -297,6 +297,11 @@ export class VPNCard extends LitElement {
       --shield-color: var(--color-enabled);
     }
 
+    div.stack,
+    .box.stable {
+      max-block-size: 156px;
+    }
+
     .infobox {
       flex: 4;
     }

--- a/src/ui/browserAction/popup.css
+++ b/src/ui/browserAction/popup.css
@@ -21,6 +21,7 @@ body {
 .limit-panel-height {
   max-height: calc(var(--window-max-height) - var(--nav-height));
   max-block-size: calc(var(--window-max-height)- var(--nav-height));
+  overflow-y: scroll;
 }
 
 .needsSlotted > * {

--- a/src/ui/browserAction/popupPage.js
+++ b/src/ui/browserAction/popupPage.js
@@ -197,7 +197,7 @@ export class BrowserActionPopup extends LitElement {
           : null}
       </vpn-titlebar>
       <stack-view ${ref(this.stackView)}>
-        <section data-title="Mozilla VPN">
+        <section data-title="Mozilla VPN" class="limit-panel-height">
           <main>
             <div class="butter-bar-holder">
               ${this.alerts.map(
@@ -571,12 +571,12 @@ export class BrowserActionPopup extends LitElement {
 
     vpn-card {
       display: block;
-      margin-bottom: calc(var(--padding-default) * 1);
+      margin-bottom: 24px;
     }
 
     h1 {
       margin-block: 0px important!;
-      padding-block: 8px 16px !important;
+      padding-block: 0px 16px !important;
     }
 
     .origin.bold {

--- a/src/ui/variables.css
+++ b/src/ui/variables.css
@@ -32,7 +32,7 @@
 
 :root {
   --window-width: 352px;
-  --window-max-height: 520px;
+  --window-max-height: 530px;
   --nav-height: 48px;
   --font-family: "Inter Regular";
   --font-family-semi-bold: "Inter Semi Bold";


### PR DESCRIPTION
Minor CSS changes to fix FXVPN-307 and FXVPN-302. Primarily allows scrolling on the main panel so that buttons may be accessed when butter bars are visible.