### PR TITLE
Hide client stability when extension is Off

### DIFF
--- a/src/components/vpncard.js
+++ b/src/components/vpncard.js
@@ -147,6 +147,7 @@ export class VPNCard extends LitElement {
               ${VPNCard.subline(
                 this.enabled,
                 this.stability,
+                this.connecting,
                 this.clientConnected
               )}
               ${timeString}
@@ -203,7 +204,7 @@ export class VPNCard extends LitElement {
       </svg>
     `;
 
-    if (!this.enabled) {
+    if (!enabled) {
       return;
     }
     switch (stability) { 

--- a/src/components/vpncard.js
+++ b/src/components/vpncard.js
@@ -203,7 +203,10 @@ export class VPNCard extends LitElement {
       </svg>
     `;
 
-    switch (stability) {
+    if (!this.enabled) {
+      return;
+    }
+    switch (stability) { 
       case VPNState.NoSignal:
         return html`<p class="subline">${errorSvg} No Signal</p>`;
       case VPNState.Unstable:

--- a/src/components/vpncard.js
+++ b/src/components/vpncard.js
@@ -207,7 +207,7 @@ export class VPNCard extends LitElement {
     if (!enabled) {
       return;
     }
-    switch (stability) { 
+    switch (stability) {
       case VPNState.NoSignal:
         return html`<p class="subline">${errorSvg} No Signal</p>`;
       case VPNState.Unstable:


### PR DESCRIPTION
Hides connection stability text when the extension is off but the client is On with an Unstable or NoSignal connection

![Screenshot 2024-12-23 101146](https://github.com/user-attachments/assets/48cd6ae9-b896-44ad-9bd4-421e2535d7cc)
