### PR TITLE
FXVPN-328: Enable telemetry by default

### DIFF
--- a/src/background/vpncontroller/states.js
+++ b/src/background/vpncontroller/states.js
@@ -217,7 +217,7 @@ export class vpnStatusResponse {
 }
 
 export class VPNSettings {
-  extensionTelemetryEnabled = false;
+  extensionTelemetryEnabled = true;
 }
 
 export class BridgeResponse {


### PR DESCRIPTION
This PR enables telemetry in the extension by default, even if the client is not installed. Note that in this state, although telemetry is 'enabled', pings won't be sent to Glean until the client has been installed and is able to do so. 