### PR TITLE
Manual Overflows

### DIFF
--- a/src/ui/browserAction/popup.css
+++ b/src/ui/browserAction/popup.css
@@ -24,6 +24,10 @@ body {
   overflow-y: scroll;
 }
 
+html {
+  overflow: hidden;
+}
+
 .needsSlotted > * {
   display: none;
 }

--- a/src/ui/browserAction/popupPage.js
+++ b/src/ui/browserAction/popupPage.js
@@ -580,7 +580,8 @@ export class BrowserActionPopup extends LitElement {
     }
 
     section.limit-panel-height {
-      overflow-y: scroll;
+      overflow-y: auto;
+      max-height: var(--window-max-height);
     }
 
     main {


### PR DESCRIPTION
So windows 10 is wierd!  The scrollbars we see are on the window, so we need to assert we don't overflow. 
Then for the stack view i use the max window height to manually force an overflow from there if the content is too large. 
I've tested this on w11 and here is w10: 
![output](https://github.com/user-attachments/assets/e5e3b6b9-e97c-422c-ac5c-86f116bc9eca)
