### PR TITLE
Bump Ext-Version

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "version": "1.25.0",
+  "version": "1.35.0",
   "author": "Mozilla",
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "version": "1.1.1",
+  "version": "1.25.0",
   "author": "Mozilla",
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",


### PR DESCRIPTION
Given we now are on .25 Epic. (Should we rename that epic to 1.25 tho?)