### PR TITLE
Other: Run CI for release branches

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - releases/*
   workflow_dispatch:
   pull_request:
     branches:


### PR DESCRIPTION
We're currently not running that, so that makes it hard for QA to get builds :) 