### PR TITLE
Fix FXVPN-409

### DIFF
--- a/src/background/proxyHandler/proxyUtils.js
+++ b/src/background/proxyHandler/proxyUtils.js
@@ -16,6 +16,19 @@ export const ProxyUtils = {
     return { type: "direct" };
   },
 
+
+  browserProxySettingIsValid(settingValue) {
+    if (!settingValue) {
+      return false;
+    }
+    return ( settingValue?.proxyType != "none" && !(
+      settingValue?.autoConfigUrl == "" && 
+      settingValue?.http == "" && 
+      settingValue?.socks == ""
+      )
+    )
+  },
+
   /**
    * Finds the servers available for provided location, orders them by weight,
    * and returns an array of proxyInfo objects.

--- a/src/background/proxyHandler/proxyUtils.js
+++ b/src/background/proxyHandler/proxyUtils.js
@@ -16,17 +16,18 @@ export const ProxyUtils = {
     return { type: "direct" };
   },
 
-
   browserProxySettingIsValid(settingValue) {
     if (!settingValue) {
       return false;
     }
-    return ( settingValue?.proxyType != "none" && !(
-      settingValue?.autoConfigUrl == "" && 
-      settingValue?.http == "" && 
-      settingValue?.socks == ""
+    return (
+      settingValue?.proxyType != "none" &&
+      !(
+        settingValue?.autoConfigUrl == "" &&
+        settingValue?.http == "" &&
+        settingValue?.socks == ""
       )
-    )
+    );
   },
 
   /**

--- a/src/background/requestHandler.js
+++ b/src/background/requestHandler.js
@@ -175,7 +175,7 @@ export class RequestHandler extends Component {
   static toDefaultProxyInfo(browserProxySettings, extState, relays) {
     if (
       extState?.useExitRelays ||
-      browserProxySettings?.value?.proxyType != "none"
+      ( browserProxySettings?.value?.proxyType != "none" && browserProxySettings?.value?.proxyType != "system" )
     ) {
       return relays;
     } else {

--- a/src/background/requestHandler.js
+++ b/src/background/requestHandler.js
@@ -132,7 +132,7 @@ export class RequestHandler extends Component {
     return (
       this.extState.bypassTunnel ||
       this.extState.useExitRelays ||
-      this.browserProxySettings.value?.value?.proxyType != "none"
+      ProxyUtils.browserProxyUrlIsSet(this.browserProxySettings?.value)
     );
   }
 
@@ -175,7 +175,7 @@ export class RequestHandler extends Component {
   static toDefaultProxyInfo(browserProxySettings, extState, relays) {
     if (
       extState?.useExitRelays ||
-      ( browserProxySettings?.value?.proxyType != "none" && browserProxySettings?.value?.proxyType != "system" )
+      ProxyUtils.browserProxyUrlIsSet(browserProxySettings?.value)
     ) {
       return relays;
     } else {

--- a/src/background/requestHandler.js
+++ b/src/background/requestHandler.js
@@ -132,7 +132,7 @@ export class RequestHandler extends Component {
     return (
       this.extState.bypassTunnel ||
       this.extState.useExitRelays ||
-      ProxyUtils.browserProxyUrlIsSet(this.browserProxySettings?.value)
+      ProxyUtils.browserProxySettingIsValid(this.browserProxySettings?.value)
     );
   }
 
@@ -175,7 +175,7 @@ export class RequestHandler extends Component {
   static toDefaultProxyInfo(browserProxySettings, extState, relays) {
     if (
       extState?.useExitRelays ||
-      ProxyUtils.browserProxyUrlIsSet(browserProxySettings?.value)
+      ProxyUtils.browserProxySettingIsValid(browserProxySettings?.value)
     ) {
       return relays;
     } else {


### PR DESCRIPTION
This is a small tweak to the work of #205 . This checks that a browser proxy settings is !-- "none" _and_ that a proxy URL has been provided. Otherwise it is entirely possible for someone to choose 'Manual proxy configuration', enter no URL, and then experience FXVPN-409 (which is I suspect what happened in Raluca's case). 

I will add tests in the AM :) 

Also: There is the matter of the 'Use system proxy settings' option in browser proxy settings that I'm not sure how to handle or what to do with. This PR would (I think) overwrite the system proxy setting (unless a proxy URL is automagically attached to the proxy setting object) so maybe that is a tweak that needs to be made. 