### PR TITLE
Fix FXVPN-412

### DIFF
--- a/src/background/proxyHandler/proxyUtils.js
+++ b/src/background/proxyHandler/proxyUtils.js
@@ -23,9 +23,9 @@ export const ProxyUtils = {
     return (
       settingValue?.proxyType != "none" &&
       !(
-        settingValue?.autoConfigUrl == "" &&
-        settingValue?.http == "" &&
-        settingValue?.socks == ""
+        settingValue?.autoConfigUrl == undefined &&
+        settingValue?.http == undefined &&
+        settingValue?.socks == undefined
       )
     );
   },

--- a/src/background/requestHandler.js
+++ b/src/background/requestHandler.js
@@ -61,7 +61,7 @@ export class RequestHandler extends Component {
 
     extController.state.subscribe((s) => {
       this.extState = s;
-      this.handleExtensionStateChanges(s);
+      return this.addOrRemoveRequestListener();
     });
 
     propertySum(
@@ -81,14 +81,6 @@ export class RequestHandler extends Component {
   updateProxyInfoFromClient(localProxy, exitRelays) {
     this.localProxyInfo = localProxy;
     this.currentExitRelay = exitRelays;
-  }
-
-  /**
-   * Handles changes in extension state and updates request listener.
-   * @param {FirefoxVPNState} extState
-   */
-  handleExtensionStateChanges(extState) {
-    return this.addOrRemoveRequestListener();
   }
 
   async init() {
@@ -132,7 +124,7 @@ export class RequestHandler extends Component {
     return (
       this.extState.bypassTunnel ||
       this.extState.useExitRelays ||
-      ProxyUtils.browserProxySettingIsValid(this.browserProxySettings?.value)
+      (this.extState.enabled && !this.extState.useExitRelays && ProxyUtils.browserProxySettingIsValid(this.browserProxySettings?.value))
     );
   }
 

--- a/src/background/requestHandler.js
+++ b/src/background/requestHandler.js
@@ -124,7 +124,9 @@ export class RequestHandler extends Component {
     return (
       this.extState.bypassTunnel ||
       this.extState.useExitRelays ||
-      (this.extState.enabled && !this.extState.useExitRelays && ProxyUtils.browserProxySettingIsValid(this.browserProxySettings?.value))
+      (this.extState.enabled &&
+        !this.extState.useExitRelays &&
+        ProxyUtils.browserProxySettingIsValid(this.browserProxySettings?.value))
     );
   }
 

--- a/src/background/toolbarIconHandler.js
+++ b/src/background/toolbarIconHandler.js
@@ -92,10 +92,9 @@ export class ToolbarIconHandler extends Component {
       return this.setIcon(scheme, "disabled", windowInfo.id);
     }
 
-    let status = ["Connecting", "Enabled"].includes(this.extState.state)
+    let status = ["Connecting", "Enabled"].includes(this.extState?.state)
       ? "enabled"
       : "disabled";
-
     const stability = this.vpnState?.connectionHealth;
 
     if (!stability || stability == "Stable") {


### PR DESCRIPTION
Fixes [FXVPN-412](https://mozilla-hub.atlassian.net/browse/FXVPN-412) - Sites with custom locations are broken when the client and extension are off if a browser level proxy setting exists. This patch modifies `proxyAllReqsByDefault` to return true when:

1. the client is On and the Extension is Off (extState.bypassTunnel == true)
2. the Client is Off and the Extension is On
3. the Client _and_ extension are both on _and_ a browser level proxy setting is present (we previously weren't removing the req listener when a browser level  proxy setting was present, thus bricking sites with custom geolocation settings)