### PR TITLE
FXVPN-440 Check Subscription Purchase Availability

### DIFF
--- a/src/background/availabilityService.js
+++ b/src/background/availabilityService.js
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @ts-check
+import { Component } from "./component.js";
+import { PropertyType } from "../shared/ipc.js";
+
+import { IBindable, property, WritableProperty } from "../shared/property.js";
+import { VPNController } from "./vpncontroller/vpncontroller.js";
+import { VPNState } from "./vpncontroller/states.js";
+
+/**
+ *
+ * ButterBarService manages 'Butter Bar' alerts shown
+ * in the UI.
+ */
+
+export class AvailablityService extends Component {
+  // Gets exposed to UI
+  static properties = {
+    isAvailable: PropertyType.Bindable,
+    check: PropertyType.Function,
+    waitlistURL: PropertyType.Bindable,
+    ignore: PropertyType.Function,
+  };
+
+  /** @type {WritableProperty<String>} */
+  // Availablity status: 
+  // Valid Strings: "pending, available, unavailable, ignored"
+  isAvailable = property("pending");
+  /** @type {WritableProperty<String>} */
+  waitlistURL = property("");
+
+  async ignore(){
+    this.isAvailable.value = "ignored";
+  }
+
+  async check(){
+    return await fetch('https://www.mozilla.org/products/vpn/', { cache: "reload" })
+        .then(response => response.text())
+        .then(htmlString => {
+            // Parse the HTML string into a document
+            const parser = new DOMParser();
+            const doc = parser.parseFromString(htmlString, 'text/html');
+            
+            // Now you can use querySelector on the parsed document
+            /** @type {HTMLAnchorElement?} */
+            const waitlistbutton = doc.querySelector(`[data-testid="join-waitlist-hero-button"]`);
+            const available = !!waitlistbutton ? "unavailable" : "available";
+            
+           
+            if(waitlistbutton){
+                const buttonURL = new URL( waitlistbutton.href);
+                const realURL = new URL("https://www.mozilla.org/")
+                realURL.pathname = buttonURL.pathname;
+                this.waitlistURL.value = realURL.toString();
+            }
+            console.log(`A vpn subscribtion is: ${available}, waitlist ${this.waitlistURL.value}`);
+
+            this.isAvailable.value = available;
+            return available; 
+        })
+        .catch(error => {
+            console.error('Error fetching or parsing the HTML:', error);
+        });
+  }
+
+  /**
+   * 
+   * @param {*} receiver 
+   * @param {VPNController} controller 
+   */
+  constructor(receiver, controller) {
+    controller.state.subscribe(state =>{
+        // We already checked if the vpn is available for the user.
+        if(this.isAvailable.value != "pending"){
+            return;
+        }
+        /**
+         * Check if the VPN is available when 
+         * the user has not yet installed the vpn 
+         * or if the user has not yet subscribed.
+         */
+        if(!state.installed){
+            this.check();
+            return;
+        }
+        if(!state.subscribed){
+            this.check();
+            return;
+        }
+    })
+    super(receiver);
+  }
+
+  async init() {}
+}

--- a/src/background/availabilityService.js
+++ b/src/background/availabilityService.js
@@ -26,71 +26,76 @@ export class AvailablityService extends Component {
   };
 
   /** @type {WritableProperty<String>} */
-  // Availablity status: 
+  // Availablity status:
   // Valid Strings: "pending, available, unavailable, ignored"
   isAvailable = property("pending");
   /** @type {WritableProperty<String>} */
   waitlistURL = property("");
 
-  async ignore(){
+  async ignore() {
     this.isAvailable.value = "ignored";
   }
 
-  async check(){
-    return await fetch('https://www.mozilla.org/products/vpn/', { cache: "reload" })
-        .then(response => response.text())
-        .then(htmlString => {
-            // Parse the HTML string into a document
-            const parser = new DOMParser();
-            const doc = parser.parseFromString(htmlString, 'text/html');
-            
-            // Now you can use querySelector on the parsed document
-            /** @type {HTMLAnchorElement?} */
-            const waitlistbutton = doc.querySelector(`[data-testid="join-waitlist-hero-button"]`);
-            const available = !!waitlistbutton ? "unavailable" : "available";
-            
-           
-            if(waitlistbutton){
-                const buttonURL = new URL( waitlistbutton.href);
-                const realURL = new URL("https://www.mozilla.org/")
-                realURL.pathname = buttonURL.pathname;
-                this.waitlistURL.value = realURL.toString();
-            }
-            console.log(`A vpn subscribtion is: ${available}, waitlist ${this.waitlistURL.value}`);
+  async check() {
+    return await fetch("https://www.mozilla.org/products/vpn/", {
+      cache: "reload",
+    })
+      .then((response) => response.text())
+      .then((htmlString) => {
+        // Parse the HTML string into a document
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(htmlString, "text/html");
 
-            this.isAvailable.value = available;
-            return available; 
-        })
-        .catch(error => {
-            console.error('Error fetching or parsing the HTML:', error);
-        });
+        // Now you can use querySelector on the parsed document
+        /** @type {HTMLAnchorElement?} */
+        const waitlistbutton = doc.querySelector(
+          `[data-testid="join-waitlist-hero-button"]`
+        );
+        const available = !!waitlistbutton ? "unavailable" : "available";
+
+        if (waitlistbutton) {
+          const buttonURL = new URL(waitlistbutton.href);
+          const realURL = new URL("https://www.mozilla.org/");
+          realURL.pathname = buttonURL.pathname;
+          this.waitlistURL.value = realURL.toString();
+        }
+        console.log(
+          `A vpn subscribtion is: ${available}, waitlist ${this.waitlistURL.value}`
+        );
+
+        this.isAvailable.value = available;
+        return available;
+      })
+      .catch((error) => {
+        console.error("Error fetching or parsing the HTML:", error);
+      });
   }
 
   /**
-   * 
-   * @param {*} receiver 
-   * @param {VPNController} controller 
+   *
+   * @param {*} receiver
+   * @param {VPNController} controller
    */
   constructor(receiver, controller) {
-    controller.state.subscribe(state =>{
-        // We already checked if the vpn is available for the user.
-        if(this.isAvailable.value != "pending"){
-            return;
-        }
-        /**
-         * Check if the VPN is available when 
-         * the user has not yet installed the vpn 
-         * or if the user has not yet subscribed.
-         */
-        if(!state.installed){
-            this.check();
-            return;
-        }
-        if(!state.subscribed){
-            this.check();
-            return;
-        }
-    })
+    controller.state.subscribe((state) => {
+      // We already checked if the vpn is available for the user.
+      if (this.isAvailable.value != "pending") {
+        return;
+      }
+      /**
+       * Check if the VPN is available when
+       * the user has not yet installed the vpn
+       * or if the user has not yet subscribed.
+       */
+      if (!state.installed) {
+        this.check();
+        return;
+      }
+      if (!state.subscribed) {
+        this.check();
+        return;
+      }
+    });
     super(receiver);
   }
 

--- a/src/background/availabilityService.js
+++ b/src/background/availabilityService.js
@@ -6,14 +6,13 @@
 import { Component } from "./component.js";
 import { PropertyType } from "../shared/ipc.js";
 
-import { IBindable, property, WritableProperty } from "../shared/property.js";
+import { property, WritableProperty } from "../shared/property.js";
 import { VPNController } from "./vpncontroller/vpncontroller.js";
-import { VPNState } from "./vpncontroller/states.js";
 
 /**
  *
- * ButterBarService manages 'Butter Bar' alerts shown
- * in the UI.
+ * AvailablityService reports if a user will be able to
+ * create a subscription in at the current location.
  */
 
 export class AvailablityService extends Component {

--- a/src/background/availabilityService.js
+++ b/src/background/availabilityService.js
@@ -41,11 +41,9 @@ export class AvailablityService extends Component {
     })
       .then((response) => response.text())
       .then((htmlString) => {
-        // Parse the HTML string into a document
         const parser = new DOMParser();
         const doc = parser.parseFromString(htmlString, "text/html");
 
-        // Now you can use querySelector on the parsed document
         /** @type {HTMLAnchorElement?} */
         const waitlistbutton = doc.querySelector(
           `[data-testid="join-waitlist-hero-button"]`
@@ -97,6 +95,5 @@ export class AvailablityService extends Component {
     });
     super(receiver);
   }
-
   async init() {}
 }

--- a/src/background/main.js
+++ b/src/background/main.js
@@ -17,7 +17,7 @@ import { TabReloader } from "./tabReloader.js";
 import { ConflictObserver } from "./conflictObserver.js";
 import { ButterBarService } from "./butterBarService.js";
 import { Telemetry } from "./telemetry.js";
-import { AvailablityService } from "./availabilityService.js";
+import { AvailabilityService } from "./availabilityService.js";
 
 const log = Logger.logger("Main");
 
@@ -59,7 +59,7 @@ class Main {
     this.vpnController,
     this.conflictObserver
   );
-  avilabilityService = new AvailablityService(this, this.vpnController);
+  availabilityService = new AvailabilityService(this, this.vpnController);
 
   async init() {
     log("Hello from the background script!");
@@ -74,7 +74,7 @@ class Main {
     expose(this.onboardingController);
     expose(this.butterBarService);
     expose(this.telemetry);
-    expose(this.avilabilityService);
+    expose(this.availabilityService);
 
     this.#handlingEvent = false;
     this.#processPendingEvents();

--- a/src/background/main.js
+++ b/src/background/main.js
@@ -17,6 +17,7 @@ import { TabReloader } from "./tabReloader.js";
 import { ConflictObserver } from "./conflictObserver.js";
 import { ButterBarService } from "./butterBarService.js";
 import { Telemetry } from "./telemetry.js";
+import { AvailablityService } from "./availabilityService.js";
 
 const log = Logger.logger("Main");
 
@@ -58,6 +59,7 @@ class Main {
     this.vpnController,
     this.conflictObserver
   );
+  avilabilityService = new AvailablityService(this, this.vpnController);
 
   async init() {
     log("Hello from the background script!");
@@ -72,6 +74,9 @@ class Main {
     expose(this.onboardingController);
     expose(this.butterBarService);
     expose(this.telemetry);
+    expose(this.avilabilityService);
+
+    this.avilabilityService.check();
 
     this.#handlingEvent = false;
     this.#processPendingEvents();

--- a/src/background/main.js
+++ b/src/background/main.js
@@ -76,8 +76,6 @@ class Main {
     expose(this.telemetry);
     expose(this.avilabilityService);
 
-    this.avilabilityService.check();
-
     this.#handlingEvent = false;
     this.#processPendingEvents();
   }

--- a/src/background/vpncontroller/states.js
+++ b/src/background/vpncontroller/states.js
@@ -36,7 +36,7 @@ export class VPNState {
   // True if firefox is split-tunneled
   isExcluded = false;
   // True if a subscription is found
-  subscribed = true;
+  subscribed = false;
   // True if it is authenticated
   authenticated = false;
   // Can be "Stable", "Unstable", "NoSignal"

--- a/src/background/vpncontroller/vpncontroller.js
+++ b/src/background/vpncontroller/vpncontroller.js
@@ -117,7 +117,7 @@ export class VPNController extends Component {
   }
 
   async init() {
-    this.#mState.value = new StateVPNClosed();
+    this.#mState.value = new StateVPNUnavailable();
     this.#mServers.value = await fromStorage(
       browser.storage.local,
       MOZILLA_VPN_SERVERS_KEY,

--- a/src/components/prefab-screens.js
+++ b/src/components/prefab-screens.js
@@ -202,7 +202,7 @@ defineMessageScreen({
   tag: "unsupported-country-message-screen",
   img: "onboarding-2.svg",
   heading: tr("headerSubscriptionNotAvailable"),
-  bodyText: html` <p>${tr("bodySubscriptionNotAvailable")}</p> `,
+  bodyText: tr("bodySubscriptionNotAvailable"),
   onPrimaryAction: () =>
     closeAfter(() => open(availabilityService.waitlistURL.value)),
   primaryAction: tr("btnjoinWaitlist"),

--- a/src/components/prefab-screens.js
+++ b/src/components/prefab-screens.js
@@ -197,7 +197,7 @@ defineMessageScreen({
   heading: tr("messageSplitTunnelHeader"),
   bodyText: tr("messageSplitTunnelBody"),
 });
-// TODO: ADD STRINGS !!
+
 defineMessageScreen({
   tag: "unsupported-country-message-screen",
   img: "onboarding-2.svg",

--- a/src/components/prefab-screens.js
+++ b/src/components/prefab-screens.js
@@ -7,7 +7,7 @@ import { MessageScreen } from "./message-screen.js";
 import { tr } from "../shared/i18n.js";
 import {
   onboardingController,
-  telemetry,
+  availabilityService
 } from "../ui/browserAction/backend.js";
 import { NUMBER_OF_ONBOARDING_PAGES } from "../background/onboarding.js";
 
@@ -197,3 +197,17 @@ defineMessageScreen({
   heading: tr("messageSplitTunnelHeader"),
   bodyText: tr("messageSplitTunnelBody"),
 });
+// TODO: ADD STRINGS !!
+defineMessageScreen({
+  tag: "unsupported-country-message-screen",
+  img: "onboarding-2.svg",
+  heading: "Mozilla VPN is not yet available in your country",
+  bodyText: html`
+    <p>Mozilla VPN isn’t available in your country yet, but you can join our waitlist to be notified when it launches. If you already have a subscription, please sign in to manage your account.</p>
+  `,
+  onPrimaryAction:  () => closeAfter(() => open(availabilityService.waitlistURL.value)),
+  primaryAction: "Join the Waitlist",
+  secondaryAction: "I already have a Subscription",
+  onSecondaryAction: () => availabilityService.ignore(),
+});
+

--- a/src/components/prefab-screens.js
+++ b/src/components/prefab-screens.js
@@ -7,7 +7,7 @@ import { MessageScreen } from "./message-screen.js";
 import { tr } from "../shared/i18n.js";
 import {
   onboardingController,
-  availabilityService
+  availabilityService,
 } from "../ui/browserAction/backend.js";
 import { NUMBER_OF_ONBOARDING_PAGES } from "../background/onboarding.js";
 
@@ -203,11 +203,15 @@ defineMessageScreen({
   img: "onboarding-2.svg",
   heading: "Mozilla VPN is not yet available in your country",
   bodyText: html`
-    <p>Mozilla VPN isn’t available in your country yet, but you can join our waitlist to be notified when it launches. If you already have a subscription, please sign in to manage your account.</p>
+    <p>
+      Mozilla VPN isn’t available in your country yet, but you can join our
+      waitlist to be notified when it launches. If you already have a
+      subscription, please sign in to manage your account.
+    </p>
   `,
-  onPrimaryAction:  () => closeAfter(() => open(availabilityService.waitlistURL.value)),
+  onPrimaryAction: () =>
+    closeAfter(() => open(availabilityService.waitlistURL.value)),
   primaryAction: "Join the Waitlist",
   secondaryAction: "I already have a Subscription",
   onSecondaryAction: () => availabilityService.ignore(),
 });
-

--- a/src/components/prefab-screens.js
+++ b/src/components/prefab-screens.js
@@ -201,17 +201,11 @@ defineMessageScreen({
 defineMessageScreen({
   tag: "unsupported-country-message-screen",
   img: "onboarding-2.svg",
-  heading: "Mozilla VPN is not yet available in your country",
-  bodyText: html`
-    <p>
-      Mozilla VPN isn’t available in your country yet, but you can join our
-      waitlist to be notified when it launches. If you already have a
-      subscription, please sign in to manage your account.
-    </p>
-  `,
+  heading: tr("headerSubscriptionNotAvailable"),
+  bodyText: html` <p>${tr("bodySubscriptionNotAvailable")}</p> `,
   onPrimaryAction: () =>
     closeAfter(() => open(availabilityService.waitlistURL.value)),
-  primaryAction: "Join the Waitlist",
-  secondaryAction: "I already have a Subscription",
+  primaryAction: tr("btnjoinWaitlist"),
+  secondaryAction: tr("btnContinue"),
   onSecondaryAction: () => availabilityService.ignore(),
 });

--- a/src/ui/browserAction/backend.js
+++ b/src/ui/browserAction/backend.js
@@ -45,6 +45,9 @@ export const butterBarService = await getExposedObject("ButterBarService");
 /** @type {ipcTelemetry} */
 export const telemetry = await getExposedObject("Telemetry");
 
+
+export const availabilityService = await getExposedObject("AvailablityService");
+
 export const ready = Promise.all([vpnController, proxyHandler]);
 
 var t1 = performance.now();

--- a/src/ui/browserAction/backend.js
+++ b/src/ui/browserAction/backend.js
@@ -45,7 +45,6 @@ export const butterBarService = await getExposedObject("ButterBarService");
 /** @type {ipcTelemetry} */
 export const telemetry = await getExposedObject("Telemetry");
 
-
 export const availabilityService = await getExposedObject("AvailablityService");
 
 export const ready = Promise.all([vpnController, proxyHandler]);

--- a/src/ui/browserAction/backend.js
+++ b/src/ui/browserAction/backend.js
@@ -45,7 +45,9 @@ export const butterBarService = await getExposedObject("ButterBarService");
 /** @type {ipcTelemetry} */
 export const telemetry = await getExposedObject("Telemetry");
 
-export const availabilityService = await getExposedObject("AvailablityService");
+export const availabilityService = await getExposedObject(
+  "AvailabilityService"
+);
 
 export const ready = Promise.all([vpnController, proxyHandler]);
 

--- a/src/ui/browserAction/popupConditional.js
+++ b/src/ui/browserAction/popupConditional.js
@@ -44,7 +44,7 @@ export class PopUpConditionalView extends LitElement {
           currentPage,
           this.onBoadingScreens,
           isExcluded,
-          isAvailable,
+          isAvailable
         );
       },
       vpnController.state,
@@ -85,7 +85,8 @@ export class PopUpConditionalView extends LitElement {
     currentOnboardingPage,
     onBoardingScreens,
     isExcluded,
-    isSubscriptionAvailable) {
+    isSubscriptionAvailable
+  ) {
     if (!supportedPlatform && !features.webExtension) {
       return html`<unsupported-os-message-screen></unsupported-os-message-screen>`;
     }

--- a/src/ui/browserAction/popupConditional.js
+++ b/src/ui/browserAction/popupConditional.js
@@ -4,7 +4,7 @@
 
 import { propertySum } from "../../shared/property.js";
 import { Utils } from "../../shared/utils.js";
-import { vpnController, onboardingController, telemetry } from "./backend.js";
+import { vpnController, onboardingController, availabilityService} from "./backend.js";
 import { NUMBER_OF_ONBOARDING_PAGES } from "../../background/onboarding.js";
 import { LitElement, html } from "../../vendor/lit-all.min.js";
 
@@ -32,20 +32,22 @@ export class PopUpConditionalView extends LitElement {
     const supportedPlatform = Utils.isSupportedOs(deviceOs.os);
 
     propertySum(
-      (state, features, currentPage, isExcluded) => {
+      (state, features, currentPage, isExcluded, isAvailable) => {
         this.targetElement = PopUpConditionalView.toSlotname(
           state,
           features,
           supportedPlatform,
           currentPage,
           this.onBoadingScreens,
-          isExcluded
+          isExcluded,
+          isAvailable,
         );
       },
       vpnController.state,
       vpnController.featureList,
       onboardingController.currentOnboardingPage,
-      vpnController.isExcluded
+      vpnController.isExcluded,
+      availabilityService.isAvailable
     );
 
     // Messages may dispatch an event requesting to send a Command to the VPN
@@ -69,6 +71,7 @@ export class PopUpConditionalView extends LitElement {
    * @param {Boolean} supportedPlatform
    * @param {Number} currentOnboardingPage
    * @param {Boolean} isExcluded
+   * @param {Boolean} isSubscriptionAvailable
    * @returns {String}
    */
   static toSlotname(
@@ -77,12 +80,15 @@ export class PopUpConditionalView extends LitElement {
     supportedPlatform,
     currentOnboardingPage,
     onBoardingScreens,
-    isExcluded
-  ) {
+    isExcluded,
+    isSubscriptionAvailable) {
     if (!supportedPlatform && !features.webExtension) {
-      return html`<unsupported-os-message-screen></unsupported-os-message-screen>`;
+      //return html`<unsupported-os-message-screen></unsupported-os-message-screen>`;
     }
-    if (!state.installed) {
+    if( (!state.installed || !state.subscribed) && isSubscriptionAvailable=="unavailable"){
+      return html`<unsupported-country-message-screen></unsupported-country-message-screen>`
+    }
+    if(!state.installed){
       return html`<install-message-screen></install-message-screen>`;
     }
     if (state.needsUpdate) {

--- a/src/ui/browserAction/popupConditional.js
+++ b/src/ui/browserAction/popupConditional.js
@@ -4,7 +4,11 @@
 
 import { propertySum } from "../../shared/property.js";
 import { Utils } from "../../shared/utils.js";
-import { vpnController, onboardingController, availabilityService} from "./backend.js";
+import {
+  vpnController,
+  onboardingController,
+  availabilityService,
+} from "./backend.js";
 import { NUMBER_OF_ONBOARDING_PAGES } from "../../background/onboarding.js";
 import { LitElement, html } from "../../vendor/lit-all.min.js";
 
@@ -85,10 +89,13 @@ export class PopUpConditionalView extends LitElement {
     if (!supportedPlatform && !features.webExtension) {
       //return html`<unsupported-os-message-screen></unsupported-os-message-screen>`;
     }
-    if( (!state.installed || !state.subscribed) && isSubscriptionAvailable=="unavailable"){
-      return html`<unsupported-country-message-screen></unsupported-country-message-screen>`
+    if (
+      (!state.installed || !state.subscribed) &&
+      isSubscriptionAvailable == "unavailable"
+    ) {
+      return html`<unsupported-country-message-screen></unsupported-country-message-screen>`;
     }
-    if(!state.installed){
+    if (!state.installed) {
       return html`<install-message-screen></install-message-screen>`;
     }
     if (state.needsUpdate) {

--- a/src/ui/browserAction/popupConditional.js
+++ b/src/ui/browserAction/popupConditional.js
@@ -87,7 +87,7 @@ export class PopUpConditionalView extends LitElement {
     isExcluded,
     isSubscriptionAvailable) {
     if (!supportedPlatform && !features.webExtension) {
-      //return html`<unsupported-os-message-screen></unsupported-os-message-screen>`;
+      return html`<unsupported-os-message-screen></unsupported-os-message-screen>`;
     }
     if (
       (!state.installed || !state.subscribed) &&

--- a/tests/jest/background/availabilityService.test.mjs
+++ b/tests/jest/background/availabilityService.test.mjs
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @ts-check
+import { AvailabilityService } from "../../../src/background/availabilityService";
+
+import {
+  describe,
+  expect,
+  jest,
+  test,
+  beforeEach,
+  afterEach,
+} from "@jest/globals"; // Import test and beforeEach/afterEach
+import { property } from "../../../src/shared/property";
+import {
+  StateVPNClosed,
+  StateVPNNeedsUpdate,
+  StateVPNOnPartial,
+  StateVPNSubscriptionNeeded,
+  StateVPNUnavailable,
+  VPNState,
+} from "../../../src/background/vpncontroller";
+
+class TestRegister {
+  registerObserver() {}
+}
+const mockVpnController = {
+  state: property(new VPNState()),
+};
+
+describe("availabilityService", () => {
+  test("Calls it's check function when the VPN State Changes", () => {
+    const target = new AvailabilityService(
+      new TestRegister(),
+      mockVpnController
+    );
+
+    target.check = jest.fn(async () => {
+      return {
+        available: "string",
+        waitlistURL: undefined,
+      };
+    });
+    // Not all states should cause a check
+    mockVpnController.state.set(new StateVPNClosed());
+    mockVpnController.state.set(new StateVPNNeedsUpdate());
+    expect(target.check).toBeCalledTimes(0);
+    // Those each should call a a check
+    mockVpnController.state.set(new StateVPNSubscriptionNeeded());
+    mockVpnController.state.set(new StateVPNUnavailable());
+    expect(target.check).toBeCalledTimes(2);
+    // Checks no longer should be done
+    target.ignore();
+    mockVpnController.state.set(new StateVPNSubscriptionNeeded());
+    mockVpnController.state.set(new StateVPNUnavailable());
+    expect(target.check).toBeCalledTimes(2); // This should not have changed then.
+  });
+});

--- a/tests/jest/background/availabilityService.test.mjs
+++ b/tests/jest/background/availabilityService.test.mjs
@@ -16,6 +16,8 @@ import {
 import { property } from "../../../src/shared/property";
 import {
   StateVPNClosed,
+  StateVPNDisabled,
+  StateVPNEnabled,
   StateVPNNeedsUpdate,
   StateVPNOnPartial,
   StateVPNSubscriptionNeeded,
@@ -44,8 +46,13 @@ describe("availabilityService", () => {
       };
     });
     // Not all states should cause a check
-    mockVpnController.state.set(new StateVPNClosed());
-    mockVpnController.state.set(new StateVPNNeedsUpdate());
+    // @ts-ignore
+    mockVpnController.state.set(new StateVPNOnPartial());
+    // @ts-ignore
+    mockVpnController.state.set(new StateVPNEnabled());
+    // @ts-ignore
+    mockVpnController.state.set(new StateVPNDisabled());
+
     expect(target.check).toBeCalledTimes(0);
     // Those each should call a a check
     mockVpnController.state.set(new StateVPNSubscriptionNeeded());


### PR DESCRIPTION
Needs Final Content. 

The idea is simple, bedrock knows whether or not a client can buy the vpn in the current locale. 
Given bedrock also does not have an api endpoint for the `vpn_available(request)` func, i'm simply loading the page in the background and use their ui-test identifiers to check if the waitlist will be shown. 

That way we can save people quite some lifetime and hopefully some frustration. 

https://github.com/user-attachments/assets/9f5e9996-4015-4a9c-b55b-6c5e2cb67b07

