### PR TITLE
Upload AMO Ready source bundle

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,9 +26,19 @@ jobs:
         with:
           name: mozilla-vpn-extension-unsigned.xpi
           path: dist/mozilla-vpn-extension-unsigned.xpi
+      - name: Create amo_sources.zip excluding node_modules
+        run: |
+          # Create a zip file excluding the node_modules folder
+          zip -r amo_sources.zip . -x "node_modules/*"
+
+      - name: Upload amo_sources.zip as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: amo_sources.zip
+          path: amo_sources.zip
 
   upload:
-    name: Upload XPI to Release
+    name: Upload XPI and Sources to Release
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -36,18 +46,24 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Download XPI
+      - name: Download XPI and Sources
         uses: actions/download-artifact@v4
         with:
           name: mozilla-vpn-extension-unsigned.xpi
+          path: .
+      - name: Download amo_sources.zip
+        uses: actions/download-artifact@v4
+        with:
+          name: amo_sources.zip
           path: .
       - name: Upload to Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           RELEASE_TAG=$(jq --raw-output '.release.tag_name' "$GITHUB_EVENT_PATH")
-          echo "Uploading mozilla-vpn-extension-unsigned.xpi to release $RELEASE_TAG"
+          echo "Uploading mozilla-vpn-extension-unsigned.xpi and amo_sources.zip to release $RELEASE_TAG"
           gh release upload "$RELEASE_TAG" "mozilla-vpn-extension-unsigned.xpi"
+          gh release upload "$RELEASE_TAG" "amo_sources.zip"
 
   notify:
     name: Notify Slack


### PR DESCRIPTION
The default gh-release sources do not include the languages, so let's also generate an amo ready source bundle when we create a draft release :) 