### PR TITLE
Perf: Check Deep Equality before passing data to UI

### DIFF
--- a/src/background/vpncontroller/vpncontroller.js
+++ b/src/background/vpncontroller/vpncontroller.js
@@ -181,15 +181,28 @@ export class VPNController extends Component {
     }
     switch (response.t) {
       case "servers":
-        this.#mServers.set(response.servers.countries);
+        if (
+          !Utils.deepEquals(response.servers.countries, this.#mServers.value)
+        ) {
+          this.#mServers.set(response.servers.countries);
+        }
         break;
       case "disabled_apps":
-        this.#mSplitTunnledApps.set(response["disabled_apps"]);
+        if (
+          !Utils.deepEquals(
+            response.disabled_apps,
+            this.#mSplitTunnledApps.value
+          )
+        ) {
+          this.#mSplitTunnledApps.set(response.disabled_apps);
+        }
         break;
       case "status":
         const newStatus = fromVPNStatusResponse(response, this.#mServers.value);
         if (newStatus) {
-          this.#mState.set(newStatus);
+          if (!Utils.deepEquals(newStatus, this.#mState.value)) {
+            this.#mState.set(newStatus);
+          }
           // Let's increase the network key isolation at any vpn status change.
           this.#increaseIsolationKey();
         }
@@ -215,7 +228,9 @@ export class VPNController extends Component {
             settings[k] = response.settings[k];
           }
         });
-        this.#settings.set(settings);
+        if (!Utils.deepEquals(settings, this.#settings.value)) {
+          this.#settings.set(settings);
+        }
         break;
       default:
         console.debug("Unexpected Message type: " + response.t);

--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -145,4 +145,84 @@ export const Utils = {
       .find((sc) => sc.code === countryCode)
       ?.cities.find((c) => c.code === cityCode);
   },
+
+  deepEquals: (a, b) => {
+    if (a === b) return true;
+    if (a == null || b == null) return false;
+
+    // Handle arrays
+    if (Array.isArray(a) && Array.isArray(b)) {
+      if (a.length !== b.length) return false;
+      for (let i = 0; i < a.length; i++) {
+        if (!Utils.deepEquals(a[i], b[i])) return false;
+      }
+      return true;
+    }
+
+    // Handle Set
+    if (a instanceof Set && b instanceof Set) {
+      if (a.size !== b.size) return false;
+      // Sets are unordered, so compare values as arrays after sorting
+      const arrA = Array.from(a).sort();
+      const arrB = Array.from(b).sort();
+      return Utils.deepEquals(arrA, arrB);
+    }
+
+    // Handle Map
+    if (a instanceof Map && b instanceof Map) {
+      if (a.size !== b.size) return false;
+      // Compare entries as arrays after sorting by key
+      const arrA = Array.from(a.entries()).sort();
+      const arrB = Array.from(b.entries()).sort();
+      return Utils.deepEquals(arrA, arrB);
+    }
+
+    // Handle plain objects
+    if (typeof a === "object" && typeof b === "object") {
+      if (
+        Array.isArray(a) ||
+        Array.isArray(b) ||
+        a instanceof Set ||
+        b instanceof Set ||
+        a instanceof Map ||
+        b instanceof Map
+      ) {
+        // Already handled above
+        return false;
+      }
+      const keysA = Object.keys(a);
+      const keysB = Object.keys(b);
+      if (keysA.length !== keysB.length) return false;
+      keysA.sort();
+      keysB.sort();
+      for (let i = 0; i < keysA.length; i++) {
+        if (keysA[i] !== keysB[i]) return false;
+        if (!Utils.deepEquals(a[keysA[i]], b[keysB[i]])) return false;
+      }
+      return true;
+    }
+
+    // Handle general iterables (not array, set, map, or plain object)
+    if (
+      typeof a === "object" &&
+      typeof b === "object" &&
+      a[Symbol.iterator] &&
+      b[Symbol.iterator] &&
+      typeof a !== "string" &&
+      typeof b !== "string"
+    ) {
+      const iterA = a[Symbol.iterator]();
+      const iterB = b[Symbol.iterator]();
+      while (true) {
+        const resultA = iterA.next();
+        const resultB = iterB.next();
+        if (resultA.done && resultB.done) return true;
+        if (resultA.done !== resultB.done) return false;
+        if (!Utils.deepEquals(resultA.value, resultB.value)) return false;
+      }
+    }
+
+    // If we reach here, the values are not equal
+    return false;
+  },
 };

--- a/tests/jest/background/utils.deepEquals.test.mjs
+++ b/tests/jest/background/utils.deepEquals.test.mjs
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, test } from "@jest/globals";
+import { Utils } from "../../../src/shared/utils";
+
+describe("Utils.deepEquals", () => {
+  test("returns true for primitives that are equal", () => {
+    expect(Utils.deepEquals(1, 1)).toBe(true);
+    expect(Utils.deepEquals("a", "a")).toBe(true);
+    expect(Utils.deepEquals(null, null)).toBe(true);
+    expect(Utils.deepEquals(undefined, undefined)).toBe(true);
+  });
+
+  test("returns false for primitives that are not equal", () => {
+    expect(Utils.deepEquals(1, 2)).toBe(false);
+    expect(Utils.deepEquals("a", "b")).toBe(false);
+    expect(Utils.deepEquals(null, undefined)).toBe(false);
+  });
+
+  test("returns true for deeply equal objects", () => {
+    expect(Utils.deepEquals({ a: 1, b: 2 }, { a: 1, b: 2 })).toBe(true);
+    expect(Utils.deepEquals([1, 2, 3], [1, 2, 3])).toBe(true);
+    expect(
+      Utils.deepEquals({ x: [1, 2], y: { z: 3 } }, { x: [1, 2], y: { z: 3 } })
+    ).toBe(true);
+  });
+
+  test("returns false for objects with different keys or values", () => {
+    expect(Utils.deepEquals({ a: 1 }, { b: 1 })).toBe(false);
+    expect(Utils.deepEquals({ a: 1 }, { a: 2 })).toBe(false);
+    expect(Utils.deepEquals([1, 2, 3], [1, 2])).toBe(false);
+    expect(Utils.deepEquals([1, 2, 3], [3, 2, 1])).toBe(false);
+  });
+
+  test("returns true for deeply equal nested arrays and objects", () => {
+    const a = { foo: [1, { bar: 2 }], baz: 3 };
+    const b = { foo: [1, { bar: 2 }], baz: 3 };
+    expect(Utils.deepEquals(a, b)).toBe(true);
+  });
+
+  test("returns false for different nested structures", () => {
+    const a = { foo: [1, { bar: 2 }], baz: 3 };
+    const b = { foo: [1, { bar: 3 }], baz: 3 };
+    expect(Utils.deepEquals(a, b)).toBe(false);
+  });
+
+  test("returns true for equal Sets and Maps", () => {
+    expect(Utils.deepEquals(new Set([1, 2]), new Set([1, 2]))).toBe(true);
+    expect(Utils.deepEquals(new Map([["a", 1]]), new Map([["a", 1]]))).toBe(
+      true
+    );
+  });
+
+  test("returns false for different Sets and Maps", () => {
+    expect(Utils.deepEquals(new Set([1, 2]), new Set([2, 3]))).toBe(false);
+    expect(Utils.deepEquals(new Map([["a", 1]]), new Map([["b", 1]]))).toBe(
+      false
+    );
+  });
+
+  test("returns false if one is iterable and the other is not", () => {
+    expect(Utils.deepEquals([1, 2, 3], { 0: 1, 1: 2, 2: 3 })).toBe(false);
+  });
+
+  test("returns true for two empty objects or arrays", () => {
+    expect(Utils.deepEquals({}, {})).toBe(true);
+    expect(Utils.deepEquals([], [])).toBe(true);
+  });
+
+  test("returns false for objects with same values but different key order", () => {
+    expect(Utils.deepEquals({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true); // Note: Object.values order is not guaranteed
+  });
+});


### PR DESCRIPTION
`Property` does not do an equality check, for good reasons, given we know any value is frozen so it is another instance.
Therefore any call to set will always call all subscriptions.

The UI has everything subscribed, so any change to a prop will be passed over IPC (meaning serializing & deserializing) 
Now when we open the browser action we will request most data to be refreshed 
```
 connectedCallback() {
    super.connectedCallback();
    requestIdleCallback(() => {
      vpnController.postToApp("status");
    });
    requestIdleCallback(() => {
      vpnController.postToApp("servers");
    });
    requestIdleCallback(() => {
      vpnController.postToApp("featurelist");
    });
    requestIdleCallback(() => {
      vpnController.postToApp("interventions");
    });
    requestIdleCallback(() => {
      telemetry.record("main_screen");
    });
  }
  ```
  Which is fine but also means we're re-calculating all dependent data i.e when updating the controller state, we will update and re-calculate all properties that subscribed to that. which then again will push their changes to the UI. 
That is a LOT of work, and we might not need it. So let's de-dupe that on the vpncontroller. 

