### PR TITLE
FXVPN-423 Apply full Firefox theme to the extension

### DIFF
--- a/src/components/butter-bar.js
+++ b/src/components/butter-bar.js
@@ -65,7 +65,7 @@ export class ButterBar extends LitElement {
     ${ghostButtonStyles}
     .butter-bar {
       margin-block-end: 16px;
-      background: var(--grey10);
+      background: lch(from var(--firefox-popup) calc(l - 10) c h);
       border-radius: 4px;
       display: flex;
       flex-direction: row;
@@ -117,10 +117,6 @@ export class ButterBar extends LitElement {
     }
 
     @media (prefers-color-scheme: dark) {
-      .butter-bar {
-        background: rgba(255, 255, 255, 0.02);
-      }
-
       a:hover {
         opacity: 0.7;
         color: #ffffff;

--- a/src/components/firefox-theme.js
+++ b/src/components/firefox-theme.js
@@ -57,18 +57,17 @@ export class FirefoxThemeImporter extends HTMLElement {
       window.matchMedia &&
       !!window.matchMedia("(prefers-color-scheme:dark)").matches;
 
+    const needsColor = (c) => FirefoxThemeImporter.IMPORT_KEYS.includes(c.key);
+
     if (!colors || !this.isValidTheme(colors)) {
-      this.importColors(isDarkMode ? DEFAULT_DARK : DEFAULT_LIGHT).filter(
-        (color) => FirefoxThemeImporter.IMPORT_KEYS.includes(color.key)
-      );
+      const defaultColors = FirefoxThemeImporter.resolveColors({
+        colors: isDarkMode ? DEFAULT_DARK : DEFAULT_LIGHT,
+      });
+      this.importColors(defaultColors.filter(needsColor));
       this.importAccentColors(null, isDarkMode);
       return;
     }
-    this.importColors(
-      colors.filter((color) =>
-        FirefoxThemeImporter.IMPORT_KEYS.includes(color.key)
-      )
-    );
+    this.importColors(colors.filter(needsColor));
     this.importAccentColors(colors, isDarkMode);
   }
 
@@ -97,6 +96,9 @@ export class FirefoxThemeImporter extends HTMLElement {
    * @param {string} prefix - The prefix to use for the CSS variables.
    */
   importColors(colors, prefix = "firefox") {
+    if (!Array.isArray(colors)) {
+      return;
+    }
     /** @type {HTMLHtmlElement} */
     var r = document.querySelector(":root");
     // Remove all previous colors with the prefix
@@ -374,7 +376,7 @@ customElements.define("firefox-theme", FirefoxThemeImporter);
 /**
  * Those variables are exported from the Dark/Light Manifest.
  */
-const DEFAULT_DARK = FirefoxThemeImporter.resolveColors({
+const DEFAULT_DARK = {
   accentcolor: null,
   bookmark_text: null,
   button_background_active: null,
@@ -427,9 +429,9 @@ const DEFAULT_DARK = FirefoxThemeImporter.resolveColors({
   input_background: "#42414D",
   input_color: "rgb(251,251,254)",
   urlbar_popup_separator: "rgb(82,82,94)",
-});
+};
 
-const DEFAULT_LIGHT = FirefoxThemeImporter.resolveColors({
+const DEFAULT_LIGHT = {
   accentcolor: null,
   bookmark_text: null,
   button_background_active: null,
@@ -484,4 +486,4 @@ const DEFAULT_LIGHT = FirefoxThemeImporter.resolveColors({
   input_background: "rgb(255,255,255)",
   urlbar_popup_hover: "rgb(240,240,244)",
   urlbar_popup_separator: "rgb(240,240,244)",
-});
+};

--- a/src/components/firefox-theme.js
+++ b/src/components/firefox-theme.js
@@ -32,13 +32,21 @@ export class FirefoxThemeImporter extends HTMLElement {
     }
     this.importColors(theme.colors);
   }
-  async importColors(colors) {
-    var r = document.querySelector(":root");
-    Object.entries(colors).forEach(([key, value]) => {
-      if (!value) {
-        return;
-      }
-      r.style.setProperty(`--firefox-${key}`, value);
+  importColors(colors) {
+    requestAnimationFrame(() => {
+      /** @type {HTMLHtmlElement} */
+      var r = document.querySelector(":root");
+      Object.values(r)
+        .filter((e) => e.startsWith("--firefox"))
+        .forEach((e) => {
+          r.style.removeProperty(e);
+        });
+      Object.entries(colors).forEach(([key, value]) => {
+        if (!value) {
+          return;
+        }
+        r.style.setProperty(`--firefox-${key}`, value);
+      });
     });
   }
 

--- a/src/components/serverlist.js
+++ b/src/components/serverlist.js
@@ -236,7 +236,7 @@ export class ServerList extends LitElement {
 
     .default-location-item {
       padding: 8px 8px 24px;
-      border-bottom: 1px solid var(--divider-color);
+      border-bottom: 1px solid var(--grey10);
       border-radius: 0px;
       margin-inline: 16px;
       width: calc(var(--window-width) - 32px);

--- a/src/components/styles.js
+++ b/src/components/styles.js
@@ -242,20 +242,16 @@ export const inUseLabel = css`
     font-weight: bold;
     margin: 0px 10px;
     padding: 6px 10px;
-    background: var(--main-card--pill-background);
+    background: lch(from var(--toolbar-icon-bg-color) l c h);
+    color: lch(from var(--toolbar-icon-bg-color) calc(mod(l - 60, 100)) c h);
     opacity: 0.9;
     border-radius: 6px;
     line-height: inherit;
   }
-
-  .in-use-light {
-    background-color: #e7e7e7;
-  }
-
   @media (prefers-color-scheme: dark) {
     .in-use {
-      background: var(--action-button-color);
-      color: var(--text-color-invert);
+      background: var(--toolbar-icon-bg-color);
+      color: lch(from var(--toolbar-icon-bg-color) 10 c h);
     }
   }
 `;

--- a/src/components/titlebar.js
+++ b/src/components/titlebar.js
@@ -66,7 +66,7 @@ export class TitleBar extends LitElement {
       align-items: center;
       block-size: var(--nav-height);
       padding: 0px 16px;
-      border-bottom: 1px solid var(--divider-color);
+      border-bottom: 1px solid var(--grey10);
     }
   `;
 }

--- a/src/components/vpncard.js
+++ b/src/components/vpncard.js
@@ -289,7 +289,7 @@ export class VPNCard extends LitElement {
       opacity: 1;
     }
     .globe-shield {
-      mix-blend-mode: luminosity;
+      mix-blend-mode: screen;
     }
     main,
     footer {

--- a/src/components/vpncard.js
+++ b/src/components/vpncard.js
@@ -270,7 +270,7 @@ export class VPNCard extends LitElement {
     }
     .box {
       border-radius: 8px;
-      background: lch(from var(--panel-bg-color) calc(l + 5) c h);
+      background: var(--grey5);
       box-shadow: var(--box-shadow-off);
     }
 
@@ -407,7 +407,6 @@ export class VPNCard extends LitElement {
     }
     @media (prefers-color-scheme: dark) {
       .box {
-        background: lch(from var(--panel-bg-color) calc(l - 10) c h);
         --shield-color: var(--color-warning);
       }
     }

--- a/src/components/vpncard.js
+++ b/src/components/vpncard.js
@@ -276,7 +276,7 @@ export class VPNCard extends LitElement {
 
     .box.on,
     .box.connecting {
-      background: var(--main-card-background);
+      background: var(--mz-card-background);
       box-shadow: var(--box-shadow-on);
     }
 
@@ -318,7 +318,7 @@ export class VPNCard extends LitElement {
     }
     .box.on *,
     .box.connecting * {
-      color: var(--main-card-text-color);
+      color: var(--mz-card-text-color);
     }
     .box.unstable {
       --shield-color: var(--color-warning);

--- a/src/components/vpncard.js
+++ b/src/components/vpncard.js
@@ -254,7 +254,7 @@ export class VPNCard extends LitElement {
       `;
     }
     return html`
-      <svg ${ref(shieldRef)}>
+      <svg ${ref(shieldRef)} class="globe-shield">
         <use xlink:href="../../assets/img/globe-shield-on.svg#globe"></use>
       </svg>
     `;
@@ -287,6 +287,9 @@ export class VPNCard extends LitElement {
     .box.connecting.allowDisconnect mz-pill {
       pointer-events: all;
       opacity: 1;
+    }
+    .globe-shield {
+      mix-blend-mode: luminosity;
     }
     main,
     footer {

--- a/src/ui/browserAction/popup-placeholder.js
+++ b/src/ui/browserAction/popup-placeholder.js
@@ -75,7 +75,7 @@ export class PopupPlaceHolder extends LitElement {
     }
     .box {
       border-radius: 8px;
-      background: lch(from var(--panel-bg-color) calc(l + 5) c h);
+      background: var(--grey5);
       display: flex;
       align-items: center;
       justify-content: space-between;

--- a/src/ui/browserAction/popup-toggles.js
+++ b/src/ui/browserAction/popup-toggles.js
@@ -137,7 +137,7 @@ export class PopupToggles extends LitElement {
       margin-inline-start: 18px;
     }
     hr {
-      color: var(--divider-color);
+      color: var(--grey10);
       width: 60%;
       align-self: center;
       margin: 12px 30px;

--- a/src/ui/browserAction/popupPage.js
+++ b/src/ui/browserAction/popupPage.js
@@ -678,7 +678,7 @@ export class BrowserActionPopup extends LitElement {
       background: lch(from var(--action-button-color) l c h / 0);
       padding-left: 48px;
       position: relative;
-      color: var(--grey50);
+      color: var(--text-color-primary);
       outline: none;
       border: 2px solid transparent;
       margin: 0;

--- a/src/ui/browserAction/popupPage.js
+++ b/src/ui/browserAction/popupPage.js
@@ -626,6 +626,7 @@ export class BrowserActionPopup extends LitElement {
       height: 20px;
       border: 1px solid var(--border-color);
       background-color: var(--panel-bg-color);
+      accent-color: var(--mz-accent-color);
     }
 
     input + p {

--- a/src/ui/options/settingsPage.js
+++ b/src/ui/options/settingsPage.js
@@ -159,7 +159,7 @@ export class SettingsPage extends LitElement {
     }
 
     .secondary {
-      color: var(--settings-secondary-text-color);
+      color: var(--grey80);
     }
 
     @media (prefers-color-scheme: dark) {

--- a/src/ui/options/settingsPage.js
+++ b/src/ui/options/settingsPage.js
@@ -92,13 +92,13 @@ export class SettingsPage extends LitElement {
 
   body {
       width: var(--window-width);
-      background-color: var(--panel-bg-color);
+      background-color: var(--grey60);
       padding: 0;
       margin: 0;
     }
 
     :host {
-      background-color: var(--panel-bg-color);
+      background-color: var(--grey60);
       display: block;
       width: 100%;
       height: 100vh;
@@ -123,7 +123,7 @@ export class SettingsPage extends LitElement {
       display: flex;
       flex-direction: row;
       padding: 20px 30px;
-      border-bottom: 1px solid var(--settings-border-color);
+      border-bottom: 1px solid var(--grey20);
       width: 100%;
       margin-bottom: 32px;
     }

--- a/src/ui/settingsPage/index.html
+++ b/src/ui/settingsPage/index.html
@@ -11,6 +11,7 @@
       http-equiv="content-security-policy"
       content="script-src 'self';img-src 'self'; font-src 'self'; connect-src 'none'; media-src 'none'; object-src 'none'; prefetch-src 'none'; child-src 'none'; frame-src 'none'; worker-src 'none';"
     />
+    <meta name="color-scheme" content="light only" />
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
     <link rel="stylesheet" href="../variables.css" />
     <title></title>
@@ -18,16 +19,106 @@
 
     <script src="settingsPage.js" type="module"></script>
     <style>
+      /**
+      * We cannot pull theme data in a content window. 
+      * Even though a theme set's firefoxes dark/light mode
+      * it does not have to set that for content pages. 
+      * So a light theme might be used but if the system is in darkmode
+      * this page will render with darkmode. 
+      * this obviously breaks all color calculation.
+      * So let's pin firefox dark/light theme and base calculation on that.
+      **/
+      @media (prefers-color-scheme: light) {
+        :root {
+          --firefox-frame: rgb(234, 234, 237);
+          --firefox-frame_inactive: rgb(240, 240, 244);
+          --firefox-icons: rgb(91, 91, 102);
+          --firefox-ntp_background: #f9f9fb;
+          --firefox-ntp_text: rgb(21, 20, 26);
+          --firefox-popup: #fff;
+          --firefox-popup_border: rgb(240, 240, 244);
+          --firefox-popup_highlight: #e0e0e6;
+          --firefox-popup_highlight_text: #15141a;
+          --firefox-popup_text: rgb(21, 20, 26);
+          --firefox-sidebar: rgb(255, 255, 255);
+          --firefox-sidebar_border: rgba(21, 20, 26, 0.1);
+          --firefox-sidebar_text: rgb(21, 20, 26);
+          --firefox-tab_background_text: rgb(21, 20, 26);
+          --firefox-tab_line: transparent;
+          --firefox-tab_selected: #fff;
+          --firefox-tab_text: rgb(21, 20, 26);
+          --firefox-toolbar: #f9f9fb;
+          --firefox-toolbar_bottom_separator: rgba(21, 20, 26, 0.1);
+          --firefox-toolbar_field: rgba(0, 0, 0, 0.05);
+          --firefox-toolbar_field_border: transparent;
+          --firefox-toolbar_field_focus: white;
+          --firefox-toolbar_field_text: rgb(21, 20, 26);
+          --firefox-toolbar_text: rgb(21, 20, 26);
+          --firefox-toolbar_top_separator: transparent;
+          --firefox-popup_action_color: rgb(91, 91, 102);
+          --firefox-button: rgba(207, 207, 216, 0.33);
+          --firefox-button_hover: rgba(207, 207, 216, 0.66);
+          --firefox-button_active: rgb(207, 207, 216);
+          --firefox-button_primary: rgb(0, 97, 224);
+          --firefox-button_primary_hover: rgb(2, 80, 187);
+          --firefox-button_primary_active: rgb(5, 62, 148);
+          --firefox-button_primary_color: rgb(251, 251, 254);
+          --firefox-input_color: rgb(21, 20, 26);
+          --firefox-input_background: rgb(255, 255, 255);
+          --firefox-urlbar_popup_hover: rgb(240, 240, 244);
+          --firefox-urlbar_popup_separator: rgb(240, 240, 244);
+        }
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --firefox-frame: rgb(28, 27, 34);
+          --firefox-frame_inactive: rgb(31, 30, 37);
+          --firefox-icons: rgb(251, 251, 254);
+          --firefox-ntp_background: rgb(43, 42, 51);
+          --firefox-ntp_text: rgb(251, 251, 254);
+          --firefox-popup: rgb(66, 65, 77);
+          --firefox-popup_border: rgb(82, 82, 94);
+          --firefox-popup_highlight: rgb(43, 42, 51);
+          --firefox-popup_highlight_text: #15141a;
+          --firefox-popup_text: rgb(251, 251, 254);
+          --firefox-sidebar: rgb(28, 27, 34);
+          --firefox-sidebar_border: rgba(251, 251, 254, 0.1);
+          --firefox-sidebar_text: rgb(249, 249, 250);
+          --firefox-tab_background_text: #fbfbfe;
+          --firefox-tab_line: transparent;
+          --firefox-tab_selected: rgba(106, 106, 120, 0.7);
+          --firefox-tab_text: rgb(255, 255, 255);
+          --firefox-toolbar: rgb(43, 42, 51);
+          --firefox-toolbar_bottom_separator: rgba(251, 251, 254, 0.1);
+          --firefox-toolbar_field: rgba(0, 0, 0, 0.3);
+          --firefox-toolbar_field_border: transparent;
+          --firefox-toolbar_field_focus: rgb(66, 65, 77);
+          --firefox-toolbar_field_text: rgb(251, 251, 254);
+          --firefox-toolbar_text: rgb(251, 251, 254);
+          --firefox-toolbar_top_separator: transparent;
+          --firefox-popup_action_color: rgb(91, 91, 102);
+          --firefox-button: rgba(0, 0, 0, 0.33);
+          --firefox-button_hover: rgba(207, 207, 216, 0.2);
+          --firefox-button_active: rgba(207, 207, 216, 0.4);
+          --firefox-button_primary: rgb(0, 221, 255);
+          --firefox-button_primary_hover: rgb(128, 235, 255);
+          --firefox-button_primary_active: rgb(170, 242, 255);
+          --firefox-button_primary_color: rgb(43, 42, 51);
+          --firefox-input_color: rgb(251, 251, 254);
+          --firefox-input_background: #42414d;
+          --firefox-urlbar_popup_hover: rgb(240, 240, 244);
+          --firefox-urlbar_popup_separator: rgb(82, 82, 94);
+          --firefox-ntp_card_background: rgb(66, 65, 77);
+        }
+      }
       body {
         margin: 0;
         padding: 0;
-        background-color: var(--panel-bg-color);
+        background-color: lch(from var(--panel-bg-color) 50 c h);
       }
     </style>
   </head>
   <body>
-    <firefox-theme></firefox-theme>
-
     <mz-settingspage></mz-settingspage>
   </body>
 </html>

--- a/src/ui/settingsPage/settingsPage.js
+++ b/src/ui/settingsPage/settingsPage.js
@@ -159,7 +159,7 @@ export class SettingsPage extends LitElement {
     }
 
     .secondary {
-      color: var(--settings-secondary-text-color);
+      color: var(--grey80);
     }
 
     @media (prefers-color-scheme: dark) {

--- a/src/ui/settingsPage/settingsPage.js
+++ b/src/ui/settingsPage/settingsPage.js
@@ -123,7 +123,7 @@ export class SettingsPage extends LitElement {
       display: flex;
       flex-direction: row;
       padding: 20px 30px;
-      border-bottom: 1px solid var(--settings-border-color);
+      border-bottom: 1px solid var(--grey20);
       width: 100%;
       margin-bottom: 32px;
     }

--- a/src/ui/settingsPage/tableElement.js
+++ b/src/ui/settingsPage/tableElement.js
@@ -80,7 +80,7 @@ export class ContextTable extends LitElement {
 
     .tableHolder {
       background: var(--grey5);
-      border: 1px solid var(--settings-border-color);
+      border: 1px solid var(--grey20);
       border-radius: 8px;
       display: flex;
       flex-direction: column;
@@ -95,11 +95,11 @@ export class ContextTable extends LitElement {
 
     .tableHeader th {
       padding-inline: 32px;
-      // border-bottom: 1px solid var(--settings-border-color);
+      // border-bottom: 1px solid var(--grey20);
     }
 
     tr {
-      border-bottom: 1px solid var(--settings-border-color);
+      border-bottom: 1px solid var(--grey20);
     }
 
     tr:last-of-type {

--- a/src/ui/settingsPage/tableElement.js
+++ b/src/ui/settingsPage/tableElement.js
@@ -79,7 +79,7 @@ export class ContextTable extends LitElement {
     ${settingTypo}
 
     .tableHolder {
-      background: lch(from var(--panel-bg-color) calc(l + 5) c h);
+      background: var(--grey5);
       border: 1px solid var(--settings-border-color);
       border-radius: 8px;
       display: flex;

--- a/src/ui/variables.css
+++ b/src/ui/variables.css
@@ -35,11 +35,6 @@
   --color-warning: #ffa436;
   --color-fatal-error: #ff6a75;
   --green50: hsl(162, 73%, 56%);
-
-  --blue50: #0060df;
-  --cyan-50: #00ddff;
-  --main-card-background: #321c64;
-  --main-card-text-color: #ffffff;
 }
 /* Globals */
 :root {
@@ -87,9 +82,9 @@
     --button-ghost-bg-color: #ffffff;
     --secondary-btn-color: #ffffff;
 
-    --action-button-color: var(--cyan-50);
-    --color-enabled: var(--cyan-50);
-    --in-copy-link-text-color: var(--cyan-50);
+    --action-button-color: var(--mz-accent-color);
+    --color-enabled: var(--mz-accent-color);
+    --in-copy-link-text-color: var(--mz-accent-color);
   }
 }
 
@@ -104,9 +99,10 @@
     --grey60: lch(from var(--panel-bg-color) calc(l - 60) c h);
     --grey80: lch(from var(--panel-bg-color) calc(l - 80) c h);
 
-    --in-copy-link-text-color: var(--blue50);
-    --color-enabled: var(--green50);
-    --action-button-color: var(--blue50);
+    --action-button-color: var(--mz-accent-color);
+    --in-copy-link-text-color: var(--mz-accent-color);
+    --color-enabled: var(--mz-accent-color);
+    
     --text-color-primary: var(--grey50);
     --text-color-headline: var(--grey60);
     --text-color-invert: #ffffff;

--- a/src/ui/variables.css
+++ b/src/ui/variables.css
@@ -63,11 +63,8 @@
   );
   --settings-link-color: var(--action-button-color);
 
-  /**
-        Note this color is not from our figma but the 
-        firefox "light" theme, otherwise it looks wierd
-        **/
   --panel-bg-color: var(--firefox-popup);
+  --toolbar-icon-bg-color: var(--firefox-icons, var(--firefox-toolbar_text));
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/ui/variables.css
+++ b/src/ui/variables.css
@@ -34,12 +34,8 @@
 :root {
   --color-warning: #ffa436;
   --color-fatal-error: #ff6a75;
-  --color-divider: #e7e7e7;
   --green50: hsl(162, 73%, 56%);
-  --grey30: #9e9e9e;
-  --grey40: #6d6d6e;
-  --grey50: #3d3d3d;
-  --grey60: #0c0c0d;
+
   --blue50: #0060df;
   --blue60: #0250bb;
   --blue70: #054096;
@@ -81,6 +77,14 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
+    --grey5: lch(from var(--panel-bg-color) calc(l + 5) c h);
+    --grey10: lch(from var(--panel-bg-color) calc(l + 10) c h);
+    --grey20: lch(from var(--panel-bg-color) calc(l + 20) c h);
+    --grey30: lch(from var(--panel-bg-color) calc(l + 30) c h);
+    --grey40: lch(from var(--panel-bg-color) calc(l + 40) c h);
+    --grey50: lch(from var(--panel-bg-color) calc(l + 50) c h);
+    --grey60: lch(from var(--panel-bg-color) calc(l + 60) c h);
+
     --border-color: lch(from var(--panel-bg-color) calc(l + 15) c h);
     --text-secondary-color: rbga(255, 255, 255, 0.6);
     --text-color-primary: #ffffff;
@@ -88,7 +92,6 @@
     --text-color-invert: var(--grey50);
     --text-secondary-color: var(#ffffff);
     --button-ghost-bg-color: #ffffff;
-    --divider-color: lch(from var(--firefox-popup) calc(l + 10) c h);
     --secondary-btn-color: #ffffff;
     --settings-secondary-text-color: rgba(255, 255, 255, 0.8);
     --settings-border-color: #e7e7e74d;
@@ -101,9 +104,16 @@
 
 @media (prefers-color-scheme: light) {
   :root {
+    --grey5: lch(from var(--panel-bg-color) calc(l - 5) c h);
+    --grey10: lch(from var(--panel-bg-color) calc(l - 10) c h);
+    --grey20: lch(from var(--panel-bg-color) calc(l - 20) c h);
+    --grey30: lch(from var(--panel-bg-color) calc(l - 30) c h);
+    --grey40: lch(from var(--panel-bg-color) calc(l - 40) c h);
+    --grey50: lch(from var(--panel-bg-color) calc(l - 50) c h);
+    --grey60: lch(from var(--panel-bg-color) calc(l - 60) c h);
+
     --in-copy-link-text-color: var(--blue50);
     --color-enabled: var(--green50);
-    --divider-color: lch(from var(--firefox-popup) calc(l - 10) c h);
     --action-button-color: var(--blue50);
     --text-color-primary: var(--grey50);
     --text-color-headline: var(--grey60);

--- a/src/ui/variables.css
+++ b/src/ui/variables.css
@@ -88,7 +88,7 @@
     --text-color-invert: var(--grey50);
     --text-secondary-color: var(#ffffff);
     --button-ghost-bg-color: #ffffff;
-    --divider-color: lch(from var(--color-divider) l c h / 0.2);
+    --divider-color: lch(from var(--firefox-popup) calc(l + 10) c h);
     --secondary-btn-color: #ffffff;
     --settings-secondary-text-color: rgba(255, 255, 255, 0.8);
     --settings-border-color: #e7e7e74d;
@@ -103,7 +103,7 @@
   :root {
     --in-copy-link-text-color: var(--blue50);
     --color-enabled: var(--green50);
-    --divider-color: var(--color-divider);
+    --divider-color: lch(from var(--firefox-popup) calc(l - 10) c h);
     --action-button-color: var(--blue50);
     --text-color-primary: var(--grey50);
     --text-color-headline: var(--grey60);

--- a/src/ui/variables.css
+++ b/src/ui/variables.css
@@ -36,7 +36,6 @@
   --color-fatal-error: #ff6a75;
   --color-divider: #e7e7e7;
   --green50: hsl(162, 73%, 56%);
-  --grey10: #e7e7e7;
   --grey30: #9e9e9e;
   --grey40: #6d6d6e;
   --grey50: #3d3d3d;

--- a/src/ui/variables.css
+++ b/src/ui/variables.css
@@ -44,7 +44,6 @@
   --main-card-background: #321c64;
   --main-card-text-color: #ffffff;
   --settings-secondary-text-color: #5b5b66;
-  --settings-border-color: #e7e7e7;
 }
 /* Globals */
 :root {
@@ -84,6 +83,7 @@
     --grey40: lch(from var(--panel-bg-color) calc(l + 40) c h);
     --grey50: lch(from var(--panel-bg-color) calc(l + 50) c h);
     --grey60: lch(from var(--panel-bg-color) calc(l + 60) c h);
+    --grey80: lch(from var(--panel-bg-color) calc(l + 80) c h);
 
     --border-color: lch(from var(--panel-bg-color) calc(l + 15) c h);
     --text-secondary-color: rbga(255, 255, 255, 0.6);
@@ -94,7 +94,6 @@
     --button-ghost-bg-color: #ffffff;
     --secondary-btn-color: #ffffff;
     --settings-secondary-text-color: rgba(255, 255, 255, 0.8);
-    --settings-border-color: #e7e7e74d;
 
     --action-button-color: var(--cyan-50);
     --color-enabled: var(--cyan-50);
@@ -111,6 +110,7 @@
     --grey40: lch(from var(--panel-bg-color) calc(l - 40) c h);
     --grey50: lch(from var(--panel-bg-color) calc(l - 50) c h);
     --grey60: lch(from var(--panel-bg-color) calc(l - 60) c h);
+    --grey80: lch(from var(--panel-bg-color) calc(l - 80) c h);
 
     --in-copy-link-text-color: var(--blue50);
     --color-enabled: var(--green50);

--- a/src/ui/variables.css
+++ b/src/ui/variables.css
@@ -37,13 +37,9 @@
   --green50: hsl(162, 73%, 56%);
 
   --blue50: #0060df;
-  --blue60: #0250bb;
-  --blue70: #054096;
-  --blue90: #09204d;
   --cyan-50: #00ddff;
   --main-card-background: #321c64;
   --main-card-text-color: #ffffff;
-  --settings-secondary-text-color: #5b5b66;
 }
 /* Globals */
 :root {
@@ -93,7 +89,6 @@
     --text-secondary-color: var(#ffffff);
     --button-ghost-bg-color: #ffffff;
     --secondary-btn-color: #ffffff;
-    --settings-secondary-text-color: rgba(255, 255, 255, 0.8);
 
     --action-button-color: var(--cyan-50);
     --color-enabled: var(--cyan-50);

--- a/src/ui/variables.css
+++ b/src/ui/variables.css
@@ -74,9 +74,11 @@
     --grey80: lch(from var(--panel-bg-color) calc(l + 80) c h);
 
     --border-color: lch(from var(--panel-bg-color) calc(l + 15) c h);
-    --text-secondary-color: rbga(255, 255, 255, 0.6);
-    --text-color-primary: #ffffff;
-    --text-color-headline: #ffffff;
+    --text-color-primary: var(--firefox-popup_text, #ffffff);
+    --text-color-headline: lch(from var(--text-color-primary) calc(l + 60) c h);
+    --text-secondary-color: lch(
+      from var(--text-color-primary) calc(l + 20) c h
+    );
     --text-color-invert: var(--grey50);
     --text-secondary-color: var(#ffffff);
     --button-ghost-bg-color: #ffffff;
@@ -102,14 +104,16 @@
     --action-button-color: var(--mz-accent-color);
     --in-copy-link-text-color: var(--mz-accent-color);
     --color-enabled: var(--mz-accent-color);
-    
-    --text-color-primary: var(--grey50);
-    --text-color-headline: var(--grey60);
+
+    --text-color-primary: var(--firefox-popup_text, black);
+    --text-color-headline: lch(from var(--text-color-primary) calc(l - 10) c h);
+    --text-secondary-color: lch(
+      from var(--text-color-primary) calc(l - 20) c h
+    );
     --text-color-invert: #ffffff;
     --border-color: lch(from var(--panel-bg-color) calc(l - 15) c h / 0.3);
     --button-ghost-bg-color: var(--grey50);
     --input-border: #8f8f9d;
     --secondary-btn-color: var(--action-button-color);
-    --text-secondary-color: var(--grey40);
   }
 }


### PR DESCRIPTION
- **Cleanup: Remove Static Color from ButterBar**
- **Cleanup: Calc Color Divider from Theme**
- **Cleanup: Calc all grayscale colors as shade of panelBG**
- **Cleanup: Calc settings-border-color**
- **Bugfix: Handle Mismatch beween theme and system setting**
- **Nit: Use grayscale colors in settings page**
- **Cleanup: Remove unused colors, remove settings-secondary-text-color**
- **Cleanup: Remove missing color usage**
- **Feat: The in use label should follow the toolbar, and keep readable text**
- **Bugfix: when the theme changes, cleanup stale properties**
- **WIP - Check the quality of the theme you are using and judge you**
- **Calculate variables from theme**
- **Let the globe Apply the background color**
- **Do a proper search inside the firefox theme for suitable colors**
- **Only resolve colors once**
- **only filter once.**
- **Fix default theme import**
- **Allow partial application of accent colors**
- **Use WCAG Relative luminance to calculate card color**
- **Use popup-text and white/dark as fallback for text styles**
- **Do not use --grey-x for text styles**
- **Use nicer mix-blend-mode**
- **use accent color in the checkbox**
