### PR TITLE
Dedupe all property things

### DIFF
--- a/src/background/availabilityService.js
+++ b/src/background/availabilityService.js
@@ -44,11 +44,11 @@ export class AvailabilityService extends Component {
         .then((s) => s);
 
       const res = AvailabilityService.checkContent(htmlString);
-      this.isAvailable.set(res.available);
+      this.isAvailable.propose(res.available);
       if (res.waitlistURL) {
-        this.waitlistURL.set(res.waitlistURL);
+        this.waitlistURL.propose(res.waitlistURL);
       } else {
-        this.waitlistURL.set("");
+        this.waitlistURL.propose("");
       }
       return res;
     } catch (error) {

--- a/src/shared/ipc.js
+++ b/src/shared/ipc.js
@@ -568,7 +568,7 @@ export const createReplicaBindable = async (name, port) => {
       ...event.data,
     };
     if (message.name === name && message.type === ACTION_PUSH) {
-      internalProp.set(message.data);
+      internalProp.propose(message.data);
     }
   });
   return internalProp.readOnly;

--- a/src/shared/property.js
+++ b/src/shared/property.js
@@ -98,12 +98,6 @@ export class WritableProperty extends IBindable {
    * @param {T} value
    */
   set(value) {
-    if (value === this.#innerValue) {
-      console.trace("Wasting set() call, value is the same as current value", {
-        current: this.#innerValue,
-        new: value,
-      });
-    }
     this.#innerValue = value;
     Object.freeze(value);
     Object.seal(value);

--- a/tests/jest/utils/property.test.mjs
+++ b/tests/jest/utils/property.test.mjs
@@ -157,3 +157,30 @@ describe("propertySum", () => {
     expect(count).toBe(4);
   });
 });
+
+describe("property.propose", () => {
+  test("Does not notify listeners if value is unchanged", () => {
+    const prop = property(1);
+    let notified = false;
+    prop.subscribe(() => (notified = true));
+    prop.propose(1); // same value
+    expect(notified).toBe(false);
+  });
+
+  test("Notifies listeners if value changes", () => {
+    const prop = property(1);
+    let notified = false;
+    prop.subscribe(() => (notified = true));
+    prop.propose(2); // different value
+    expect(notified).toBe(true);
+    expect(prop.value).toBe(2);
+  });
+
+  test("Updates value only if different", () => {
+    const prop = property("a");
+    prop.propose("a");
+    expect(prop.value).toBe("a");
+    prop.propose("b");
+    expect(prop.value).toBe("b");
+  });
+});


### PR DESCRIPTION
By doing simple equality check we can save about 20% of property.subscriptions that do absolutely nothing on startup/ opening the popup. 