### PR TITLE
fix: update excluded page action icon based on theme

### DIFF
--- a/src/background/tabHandler.js
+++ b/src/background/tabHandler.js
@@ -75,6 +75,16 @@ export class TabHandler extends Component {
     this.maybeShowIcon();
   }
 
+  static getExcludedIconPath() {
+    const darkMode =
+      window.matchMedia &&
+      window.matchMedia("(prefers-color-scheme: dark)").matches;
+
+    return darkMode
+      ? "../assets/logos/logo-light-excluded.svg"
+      : "../assets/logos/logo-dark-excluded.svg";
+  }
+
   async maybeShowIcon() {
     if (!this.siteContexts) {
       return;
@@ -91,11 +101,9 @@ export class TabHandler extends Component {
     this.currentContext = this.siteContexts.get(this.currentHostname);
 
     if (this.currentContext && this.currentContext.excluded) {
-      // PageAction icons are automagically updated by the
-      // browser in response to theme changes so we don't
-      // don't need to specify theme specific icons here.
+      // Update excluded icon based on the active browser theme.
       browser.pageAction.setIcon({
-        path: `../assets/logos/logo-dark-excluded.svg`,
+        path: TabHandler.getExcludedIconPath(),
         tabId: currentTab.id,
       });
       browser.pageAction.setTitle({


### PR DESCRIPTION
The excluded page action icon used a static dark asset, which made it difficult to see in Firefox dark mode.

This change updates the excluded icon path dynamically based on the active browser color scheme so the icon remains visible in both light and dark themes.

For testing, I temporarily forced the excluded page action state locally and verified the icon behavior in:

* Firefox light theme
* Firefox dark theme
* Private browsing windows

I initially considered updating the excluded SVG asset directly, but that caused inverse visibility issue in light themes. I noticed the excluded `pageAction` icon did not automatically adapt to theme changes when using an explicit `setIcon()` path, so the excluded icon selection is now handled explicitly here.

Fixes: mozilla-mobile/mozilla-vpn-client#11312
